### PR TITLE
Build/publish to sonatype

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,12 @@ Light-weight, modular, libraries for varying technology stacks, built _primarily
 
 ## Quickstart
 
-Current version is `0.1.0-SNAPSHOT`.
-
-*_Currently there is no CI that automatically publishes versions, so you'll have to clone the repo, and do a `+ publishLocal` from the `sbt` repl for each module(`core`). This will be fixed ASAP._*
+Current version is `0.1.0`. All modules share this same version.  
 
 These modules are are cross-compiled for Scala versions: `2.12.3` and `2.11.11`. We try our best to keep them up to date.
 
 Modules:
-* `"com.busymachines" %% "busymachines-commons-core" % "0.1.0-SNAPSHOT"` [README.md](/core)
+* `"com.busymachines" %% "busymachines-commons-core" % "0.1.0"` [README.md](/core)
 
 ## Library Structure
 
@@ -19,10 +17,10 @@ The idea behind these sets of libraries is to help jumpstart backend RESTful api
 
 Basically, as long as modules reside in the same repository they will be versioned with the same number, and released at the same time to avoid confusion. The moment we realize that a module has to take a life of its own, it will be moved to a separate module and versioned independently.
 
-* [core](/core) `0.1.0-SNAPSHOT`
+* [core](/core) `0.1.0`
 
 ### Current version
-The latest version is `N/A`. Will keep you up to date.
+The latest version is `0.1.0`. All modules share this same version. They might start diverging at some time in the future.
 
 ## Developer's Guide
 
@@ -35,6 +33,11 @@ The build is fairly straightforward. The root folder contains a phantom build fr
 ## Contributing
 
 Currently, if you want to contribute use the `fork+pull request` model, and Busy Machines team members will have a look at your PR asap. Currently, the active maintainers of this library are:
+* @lorandszakacs
+
+### Contributors
+
+People who have contributed to the new version are:
 * @lorandszakacs
 
 ### History
@@ -58,7 +61,3 @@ You can use github API to get a list of contributors from a public project. At t
 ```
 curl -i -H "Accept: application/json" -H "Content-Type: application/json" -X GET https://api.github.com/repos/busymachines/busymachines-commons/contributors  > contributors.json
 ```
-### Contributors
-
-People who have contributed to the new version are:
-* @lorandszakacs

--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ The latest version is `N/A`. Will keep you up to date.
 
 ## Developer's Guide
 
-This section will have to be expanded more once there are more projects living here.
+If you are responsible for publishing this library then you _have_ to follow instructions listed in [z-publishing-artifacts/README.md](z-publishing-artifacts/README.md), otherwise you can simply ignore that folder.
+
+### build structure
+The build is fairly straightforward. The root folder contains a phantom build from which all modules are configured, and an essentially empty project "busymachines-commons" that is never published, but one that is extremely useful for importing into your IDEs. Most top level folders `X` correspond to the specific `busymachines-commons-X` library. All dependencies are spelled out in the `./build.sbt` file
+
 
 ## Contributing
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,15 @@ import sbt._
 import Keys._
 
 /**
+  * * All instructions for publishing to sonatype can be found in the
+  * ``z-publishing-artifcats/README.md`` folder.
+  *
+  * @author Lorand Szakacs, lsz@lorandszakacs.com, lorand.szakacs@busymachines.com
+  * @since 31 Jul 2017
+  */
+
+
+/**
   * this is used when a module depends on another, and it explicitly
   * states that the "compile", i.e. the sources, of a module depend
   * on the sources of another module. And the same thing for tests,
@@ -9,9 +18,22 @@ import Keys._
   */
 val `compile->compile;test->test` = "compile->compile;test->test"
 
-name in ThisProject := "busymachines-commons"
+/**
+  * this is a phantom project that is simply supposed to aggregate all modules for convenience,
+  * it is NOT published as an artifact. It doesn't have any source files, it is just a convenient
+  * way to propagate all commands to the modules via the aggregation
+  */
+lazy val root = Project(
+  id = "busymachines-commons",
+  base = file("."))
+  .settings(publishArtifact in ThisProject := false)
+  .aggregate(
+    core
+  )
 
-lazy val core = project.settings(Settings.commonSettings)
+lazy val core = project
+  .settings(Settings.commonSettings)
+  .settings(PublishingSettings.sonatypeSettings)
   .settings(
     libraryDependencies += Dependencies.scalaTest % Test withSources()
   )

--- a/core/README.md
+++ b/core/README.md
@@ -1,6 +1,13 @@
 # busymachines-commons-core
 
+## artifacts
+
 This module is vanilla scala _*only*_, cross-compiled against versions `2.11.11`, `2.12.3`.
+
+The full module id is:
+`"com.busymachines" %% "busymachines-commons-core" % "0.1.0"`
+
+## Description
 
 Here you find very basic buildings blocks for structuring your exceptions in meaningful ways, and very basic types. Generally, we are very conservative in what we put here, and this core will become stable really fast.
 
@@ -24,7 +31,7 @@ Which can be used in two differing styles.
 ```scala
 val option: Option[String] = ??? //...
 option.getOrElse(throw NotFoundFailure)
-option.getOrElse(throw NotFoundFailure("this specific option, instead of generic"))
+option.getOrElse(throw NotFoundFailure("this specific message, instead of generic"))
 
 ```
 

--- a/core/version.sbt
+++ b/core/version.sbt
@@ -1,1 +1,1 @@
-version := "0.1.0-SNAPSHOT"
+version := "0.1.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import Keys._
 
 object Dependencies {
 
-  lazy val commonsVersion = "0.1.0-SNAPSHOT"
+  lazy val commonsVersion = "0.1.0"
 
   lazy val scalaTest: ModuleID = "org.scalatest" %% "scalatest" % "3.0.1" withSources()
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,9 @@ import Keys._
 
 object Dependencies {
 
-  lazy val scalaTest: ModuleID = "org.scalatest" %% "scalatest" % "3.0.1"
+  lazy val commonsVersion = "0.1.0-SNAPSHOT"
 
-  lazy val busymachinesCommonsCore: ModuleID = "com.busymachines" %% "busymachines-commons-core" % "0.1.0-SNAPSHOT"
+  lazy val scalaTest: ModuleID = "org.scalatest" %% "scalatest" % "3.0.1" withSources()
+
+  lazy val busymachinesCommonsCore: ModuleID = "com.busymachines" %% "busymachines-commons-core" % commonsVersion withSources()
 }

--- a/project/PublishingSettings.scala
+++ b/project/PublishingSettings.scala
@@ -37,12 +37,13 @@ object PublishingSettings {
 
     pomIncludeRepository := { _ => false },
 
-    publishTo := Some(
+    publishTo := {
+      val nexus = "https://oss.sonatype.org/"
       if (isSnapshot.value)
-        Opts.resolver.sonatypeSnapshots
+        Some("snapshots" at nexus + "content/repositories/snapshots")
       else
-        Opts.resolver.sonatypeStaging
-    ),
+        Some("releases" at nexus + "service/local/staging/deploy/maven2")
+    },
 
     publishArtifact in Test := false,
 
@@ -50,8 +51,8 @@ object PublishingSettings {
 
     scmInfo := Some(
       ScmInfo(
-        url("https://github.com/(account)/(project)"),
-        "scm:git@github.com:(account)/(project).git"
+        url("https://github.com/busymachines/busymachines-commons"),
+        "scm:git@github.com:busymachines/busymachines-commons.git"
       )
     ),
     developers := List(

--- a/project/PublishingSettings.scala
+++ b/project/PublishingSettings.scala
@@ -1,0 +1,62 @@
+import sbt._
+import Keys._
+import com.typesafe.sbt.SbtPgp.autoImportImpl._
+import xerial.sbt.Sonatype.SonatypeKeys._
+
+/**
+  * All instructions for publishing to sonatype can be found on the sbt-plugin page:
+  * http://www.scala-sbt.org/release/docs/Using-Sonatype.html
+  *
+  * and some here:
+  *
+  * https://github.com/xerial/sbt-sonatype
+  *
+  * VERY IMPORTANT!!! You need to add credentials as described here:
+  * http://www.scala-sbt.org/release/docs/Using-Sonatype.html#Second+-+Configure+Sonatype+integration
+  *
+  * The username and password are the same as those to the Sonatype JIRA account.
+  * https://issues.sonatype.org/browse/OSSRH-33718
+  *
+  * And then you need to ensure PGP keys to sign the maven artifacts:
+  * http://www.scala-sbt.org/release/docs/Using-Sonatype.html#PGP+Tips%E2%80%99n%E2%80%99tricks
+  * Which means that you need to have PGP installed
+  *
+  * To avoid pushing sensitive information to github you must put all PGP related things in your local configs:
+  * as described here:
+  *
+  * https://github.com/sbt/sbt-pgp/issues/69
+  */
+object PublishingSettings {
+
+  def sonatypeSettings: Seq[Setting[_]] = Seq(
+    useGpg := true,
+
+    sonatypeProfileName := Settings.organizationName,
+
+    publishMavenStyle := true,
+
+    pomIncludeRepository := { _ => false },
+
+    publishTo := Some(
+      if (isSnapshot.value)
+        Opts.resolver.sonatypeSnapshots
+      else
+        Opts.resolver.sonatypeStaging
+    ),
+
+    publishArtifact in Test := false,
+
+    licenses := Seq("APL2" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt")),
+
+    scmInfo := Some(
+      ScmInfo(
+        url("https://github.com/(account)/(project)"),
+        "scm:git@github.com:(account)/(project).git"
+      )
+    ),
+    developers := List(
+      Developer(id = "lorandbm", name = "Lorand Szakacs", email = "lorand.szakacs@busymachines.com", url = url("https://github.com/lorandszakacs"))
+    )
+  )
+
+}

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -9,9 +9,12 @@ object Settings {
 
   lazy val organizationName: String = "com.busymachines"
 
+  lazy val bmCommonsHomepage: String = "https://github.com/busymachines/busymachines-commons"
+
   def commonSettings: Seq[Setting[_]] =
     Seq(
       organization in ThisBuild := organizationName,
+      homepage := Some(url(bmCommonsHomepage)),
       scalaVersion in ThisBuild := `scala_2.12`,
       crossScalaVersions in ThisBuild := seqOfCrossScalaVersions
     ) ++

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,4 @@
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+

--- a/z-publishing-artifacts/README.md
+++ b/z-publishing-artifacts/README.md
@@ -1,0 +1,71 @@
+# SBT local config example
+
+This folder is useful to you _only_ if you are responsible for publishing this library to the Sonatype repository, otherwise it can be completely ignored.
+
+The contents of this folder ought to be copied to your `~/.sbt/0.13` folder. And the appropriate values assigned to each sbt key.
+
+## [plugins/plugins.sbt](plugins/plugins.sbt)
+
+Note that for this to work you need to have [PGP installed](https://gpgtools.org/) on your machine! By defauly this build will look that it has a `pgp` command available in your `$PATH`.
+
+
+Loads the [sbt-pgp](https://github.com/sbt/sbt-pgp) as a global plugin for you machine, and [pgp.sbt](pgp.sbt) contains the paths to your PGP keys, and—optionally—the path to the `gpg` command on your system if it's not available in your global `$PATH` variable`:
+
+```scala
+com.typesafe.sbt.pgp.PgpKeys.pgpSecretRing := file("~/.gnupgp/secring.asc")
+com.typesafe.sbt.pgp.PgpKeys.pgpPublicRing := file("~/.gnupgp/pubring.asc")
+// com.typesafe.sbt.pgp.PgpKeys.gpgCommand := "/path/to/gpg"
+```
+
+## [sonatype.sbt](sonatype.sbt)
+
+This file contains the username and passwords for the Sonatype repository:
+
+```scala
+credentials += Credentials(
+  "Sonatype Nexus Repository Manager",
+  "oss.sonatype.org",
+  "$USERNAME_ON_SONATYPE_JIRA",
+  "$PASSWORD_ON_SONATYPE_JIRA"
+)
+```
+
+Currently we have only one sonatype user who uses this account, as can be seen in this issue on their JIRA:
+[https://issues.sonatype.org/browse/OSSRH-33718](https://issues.sonatype.org/browse/OSSRH-33718)
+
+## After everything is setup
+
+You ought to follow the instructions here to create your PGP file:
+[http://www.scala-sbt.org/release/docs/Using-Sonatype.html#PGP+Tips%E2%80%99n%E2%80%99tricks](http://www.scala-sbt.org/release/docs/Using-Sonatype.html#PGP+Tips%E2%80%99n%E2%80%99tricks)
+
+## Publishing
+
+Full workflow to [publish to sonatype](http://www.scala-sbt.org/release/docs/Using-Sonatype.html#Using+Sonatype) can be found on the sbt website, and you really need to read it all.
+
+And then you run the commands outlined on the [sbt-sonatype](https://github.com/xerial/sbt-sonatype#publishing-your-artifact) page. Copy pasted from there for our convenience:
+-------
+The general steps for publishing your artifact to the Central Repository are as follows:
+
+ * `publishSigned` to deploy your artifact to staging repository at Sonatype.
+ * `sonatypeRelease` do `sonatypeClose` and `sonatypePromote` in one step.
+   * `sonatypeClose` closes your staging repository at Sonatype. This step verifies Maven central sync requirement, GPG-signature, javadoc
+   and source code presence, pom.xml settings, etc.
+   * `sonatypePromote` command verifies the closed repository so that it can be synchronized with Maven central.
+
+
+Note: If your project version has "SNAPSHOT" suffix, your project will be published to the [snapshot repository](http://oss.sonatype.org/content/repositories/snapshots) of Sonatype, and you cannot use `sonatypeRelease` command.
+
+### Command Line Usage
+
+Publish a GPG-signed artifact to Sonatype:
+```
+$ sbt publishSigned
+```
+
+Do close and promote at once:
+```
+$ sbt sonatypeRelease
+```
+This command accesses [Sonatype Nexus REST API](https://oss.sonatype.org/nexus-staging-plugin/default/docs/index.html), then sends close and promote commands.
+
+```

--- a/z-publishing-artifacts/README.md
+++ b/z-publishing-artifacts/README.md
@@ -40,10 +40,14 @@ You ought to follow the instructions here to create your PGP file:
 
 ## Publishing
 
-Full workflow to [publish to sonatype](http://www.scala-sbt.org/release/docs/Using-Sonatype.html#Using+Sonatype) can be found on the sbt website, and you really need to read it all.
+Full workflow to [publish to sonatype](http://www.scala-sbt.org/release/docs/Using-Sonatype.html#Using+Sonatype) can be found on the sbt website, and you really need to read it all. _DO NOT FORGET_ to distribute your PGP keys to the keyserver pool by running the sbt task from `PGP Tips'n'tricks` section from the aforementione guide.
 
-And then you run the commands outlined on the [sbt-sonatype](https://github.com/xerial/sbt-sonatype#publishing-your-artifact) page. Copy pasted from there for our convenience:
--------
+### Open staging profile
+
+Outlined here on the [sbt-sonatype](https://github.com/xerial/sbt-sonatype/blob/master/workflow.md) plugin page.
+
+### Then Run the commands outlined on the [sbt-sonatype](https://github.com/xerial/sbt-sonatype#publishing-your-artifact) page. Copy pasted from there for our convenience:
+
 The general steps for publishing your artifact to the Central Repository are as follows:
 
  * `publishSigned` to deploy your artifact to staging repository at Sonatype.
@@ -55,7 +59,7 @@ The general steps for publishing your artifact to the Central Repository are as 
 
 Note: If your project version has "SNAPSHOT" suffix, your project will be published to the [snapshot repository](http://oss.sonatype.org/content/repositories/snapshots) of Sonatype, and you cannot use `sonatypeRelease` command.
 
-### Command Line Usage
+#### Command Line Usage
 
 Publish a GPG-signed artifact to Sonatype:
 ```

--- a/z-publishing-artifacts/README.md
+++ b/z-publishing-artifacts/README.md
@@ -50,6 +50,7 @@ Outlined here on the [sbt-sonatype](https://github.com/xerial/sbt-sonatype/blob/
 
 The general steps for publishing your artifact to the Central Repository are as follows:
 
+ * `sonatypeOpen "com.busymachines" "combusymachines-$X"` — this lives until you do `sonatypeClose`
  * `publishSigned` to deploy your artifact to staging repository at Sonatype.
  * `sonatypeRelease` do `sonatypeClose` and `sonatypePromote` in one step.
    * `sonatypeClose` closes your staging repository at Sonatype. This step verifies Maven central sync requirement, GPG-signature, javadoc
@@ -71,5 +72,4 @@ Do close and promote at once:
 $ sbt sonatypeRelease
 ```
 This command accesses [Sonatype Nexus REST API](https://oss.sonatype.org/nexus-staging-plugin/default/docs/index.html), then sends close and promote commands.
-
 ```

--- a/z-publishing-artifacts/pgp.sbt
+++ b/z-publishing-artifacts/pgp.sbt
@@ -2,6 +2,6 @@ com.typesafe.sbt.pgp.PgpKeys.pgpSecretRing := file("~/.gnupgp/secring.asc")
 com.typesafe.sbt.pgp.PgpKeys.pgpPublicRing := file("~/.gnupgp/pubring.asc")
 // com.typesafe.sbt.pgp.PgpKeys.gpgCommand := "/path/to/gpg"
 
-//for easy copy pasting just run this in your sbt console:
+//for easy copy pasting just run this in your sbt scala REPL (invoked by > console):
 // """thepasswordofthekey""".map(c => s""" '$c' """).mkString(",")
 com.typesafe.sbt.pgp.PgpKeys.pgpPassphrase := Some(Array('t', 'h', 'e', 'p', 'a', 's', 'w', 'o', 'r', 'd', 'o', 'f', 't', 'h', 'e', 'k', 'e', 'y'))

--- a/z-publishing-artifacts/pgp.sbt
+++ b/z-publishing-artifacts/pgp.sbt
@@ -1,0 +1,7 @@
+com.typesafe.sbt.pgp.PgpKeys.pgpSecretRing := file("~/.gnupgp/secring.asc")
+com.typesafe.sbt.pgp.PgpKeys.pgpPublicRing := file("~/.gnupgp/pubring.asc")
+// com.typesafe.sbt.pgp.PgpKeys.gpgCommand := "/path/to/gpg"
+
+//for easy copy pasting just run this in your sbt console:
+// """thepasswordofthekey""".map(c => s""" '$c' """).mkString(",")
+com.typesafe.sbt.pgp.PgpKeys.pgpPassphrase := Some(Array('t', 'h', 'e', 'p', 'a', 's', 'w', 'o', 'r', 'd', 'o', 'f', 't', 'h', 'e', 'k', 'e', 'y'))

--- a/z-publishing-artifacts/plugins/plugins.sbt
+++ b/z-publishing-artifacts/plugins/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")

--- a/z-publishing-artifacts/sonatype.sbt
+++ b/z-publishing-artifacts/sonatype.sbt
@@ -1,0 +1,10 @@
+/**
+  * See for the user accounts that can have access:
+  * https://issues.sonatype.org/browse/OSSRH-33718
+  */
+credentials += Credentials(
+  "Sonatype Nexus Repository Manager",
+  "oss.sonatype.org",
+  "$USERNAME_ON_SONATYPE_JIRA",
+  "$PASSWORD_ON_SONATYPE_JIRA"
+)


### PR DESCRIPTION
Prepared everything for the release of version `0.1.0`—which I'll be doing manually, since I am the only one who has the rights to publish this thing 😄 

I wrote everything in the `z-publishing-artifacts/README.md` folder. Once CI is set up, we can automate it.

After I merge this I will create a tag, and publish it to maven central.

@busymachines/scala-devs