### PR TITLE
0.2.0 rc3

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,21 +14,21 @@ Known issues:
 
 #### versions
 * stable: `0.1.0`
-* latest: `0.2.0-RC2`
+* latest: `0.2.0-RC3`
 
 These modules are are cross-compiled for Scala versions: `2.12.3`. We try our best to keep them up to date.
 
 #### Modules:
-* `"com.busymachines" %% "busymachines-commons-core" % "0.2.0-RC2"` [README.md](/core)
-* `"com.busymachines" %% "busymachines-commons-json" % "0.2.0-RC2"` [README.md](/json)
-* `"com.busymachines" %% "busymachines-commons-rest-core" % "0.2.0-RC2"` [README.md](/rest-core)
-* `"com.busymachines" %% "busymachines-commons-rest-core-testkit" % "0.2.0-RC2" % Test` [README.md](/rest-core-testkit)
-* `"com.busymachines" %% "busymachines-commons-rest-json" % "0.2.0-RC2"` [README.md](/rest-json)
-* `"com.busymachines" %% "busymachines-commons-rest-json-testkit" % "0.2.0-RC2" % Test` [README.md](/rest-json-testkit)
+* `"com.busymachines" %% "busymachines-commons-core" % "0.2.0-RC3"` [README.md](/core)
+* `"com.busymachines" %% "busymachines-commons-json" % "0.2.0-RC3"` [README.md](/json)
+* `"com.busymachines" %% "busymachines-commons-rest-core" % "0.2.0-RC3"` [README.md](/rest-core)
+* `"com.busymachines" %% "busymachines-commons-rest-core-testkit" % "0.2.0-RC3" % Test` [README.md](/rest-core-testkit)
+* `"com.busymachines" %% "busymachines-commons-rest-json" % "0.2.0-RC3"` [README.md](/rest-json)
+* `"com.busymachines" %% "busymachines-commons-rest-json-testkit" % "0.2.0-RC3" % Test` [README.md](/rest-json-testkit)
 
 For easy copy-pasting:
 ```scala
-lazy val bmCommonsVersion: String = "0.2.0-RC2"
+lazy val bmCommonsVersion: String = "0.2.0-RC3"
 
 lazy val bmCommonsCore = "com.busymachines" %% "busymachines-commons-core" % bmCommonsVersion
 lazy val bmCommonsJson = "com.busymachines" %% "busymachines-commons-json" % bmCommonsVersion
@@ -45,11 +45,11 @@ The idea behind these sets of libraries is to help jumpstart backend RESTful api
 Basically, as long as modules reside in the same repository they will be versioned with the same number, and released at the same time to avoid confusion. The moment we realize that a module has to take a life of its own, it will be moved to a separate module and versioned independently.
 
 * [core](/core) `0.1.0`
-* [json](/json) `0.2.0-RC2`
-* [rest-core](/rest-core) `0.2.0-RC2` - this is an abstract implementation that still requires specific serialization/deserialization
-* [rest-core-testkit](/rest-core-testkit) `0.2.0-RC2` - contains helpers that allow testing. Should never wind up in production code.
-* [rest-json](/rest-core) `0.2.0-RC2` - used to implement REST APIs that handle JSON
-* [rest-json-testkit](/rest-json-testkit) `0.2.0-RC2` - helpers for JSON powered REST APIs
+* [json](/json) `0.2.0-RC3`
+* [rest-core](/rest-core) `0.2.0-RC3` - this is an abstract implementation that still requires specific serialization/deserialization
+* [rest-core-testkit](/rest-core-testkit) `0.2.0-RC3` - contains helpers that allow testing. Should never wind up in production code.
+* [rest-json](/rest-core) `0.2.0-RC3` - used to implement REST APIs that handle JSON
+* [rest-json-testkit](/rest-json-testkit) `0.2.0-RC3` - helpers for JSON powered REST APIs
 
 Most likely you don't need to depend on the `rest-core*` modules. But rather on one or more of its reifications like `rest-json`. This separation was done because in the future we might need non-json REST APIs, and then we still want to have a common experience of using `commons`.
 

--- a/json/README.md
+++ b/json/README.md
@@ -1,7 +1,7 @@
 # busymachines-commons-json
 
-Current version is `0.2.0-RC2`. SBT module id:
-`"com.busymachines" %% "busymachines-commons-json" % "0.2.0-RC2"`
+Current version is `0.2.0-RC3`. SBT module id:
+`"com.busymachines" %% "busymachines-commons-json" % "0.2.0-RC3"`
 
 ## How it works
 This module is a thin layer over [circe](https://circe.github.io/circe/), additionally, it depends on [shapeless](https://github.com/milessabin/shapeless). The latter being the mechanism through which `autoderive` and `derive` derivation can be made to work.

--- a/json/src/main/scala/busymachines/json/JsonSyntax.scala
+++ b/json/src/main/scala/busymachines/json/JsonSyntax.scala
@@ -33,6 +33,12 @@ trait JsonSyntax {
     def decodeAs[A](implicit decoder: Decoder[A]): JsonDecodingResult[A] = {
       JsonDecoding.decodeAs[A](js)
     }
+
+    def noSpacesNoNulls: String = js.pretty(PrettyJson.noSpacesNoNulls)
+
+    def spaces2NoNulls: String = js.pretty(PrettyJson.spaces2NoNulls)
+
+    def spaces4NoNulls: String = js.pretty(PrettyJson.spaces4NoNulls)
   }
 
 }

--- a/json/src/test/scala/busymachines/json_test/autoderive/JsonAutoDerivationWithSpecialConfigurationTest.scala
+++ b/json/src/test/scala/busymachines/json_test/autoderive/JsonAutoDerivationWithSpecialConfigurationTest.scala
@@ -1,4 +1,4 @@
-package busymachines.json_test.auto
+package busymachines.json_test.autoderive
 
 import busymachines.json_test._
 import org.scalatest.FlatSpec

--- a/json/src/test/scala/busymachines/json_test/autoderive/JsonDefaultAutoDerivationCompilationTest.scala
+++ b/json/src/test/scala/busymachines/json_test/autoderive/JsonDefaultAutoDerivationCompilationTest.scala
@@ -1,4 +1,4 @@
-package busymachines.json_test.auto
+package busymachines.json_test.autoderive
 
 import busymachines.json_test._
 import org.scalatest.FlatSpec

--- a/json/src/test/scala/busymachines/json_test/autoderive/JsonDefaultAutoDerivationTest.scala
+++ b/json/src/test/scala/busymachines/json_test/autoderive/JsonDefaultAutoDerivationTest.scala
@@ -1,4 +1,4 @@
-package busymachines.json_test.auto
+package busymachines.json_test.autoderive
 
 import busymachines.json_test._
 import org.scalatest.FlatSpec

--- a/json/src/test/scala/busymachines/json_test/autoderive/JsonDefaultAutoSemiAutoInteractionTest.scala
+++ b/json/src/test/scala/busymachines/json_test/autoderive/JsonDefaultAutoSemiAutoInteractionTest.scala
@@ -1,4 +1,4 @@
-package busymachines.json_test.auto
+package busymachines.json_test.autoderive
 
 import busymachines.json_test._
 

--- a/json/src/test/scala/busymachines/json_test/derive/JsonDefaultSemiAutoCodecDerivationTest.scala
+++ b/json/src/test/scala/busymachines/json_test/derive/JsonDefaultSemiAutoCodecDerivationTest.scala
@@ -1,4 +1,4 @@
-package busymachines.json_test.semiauto
+package busymachines.json_test.derive
 
 import busymachines.json_test._
 import org.scalatest.FlatSpec

--- a/json/src/test/scala/busymachines/json_test/derive/JsonDefaultSemiAutoDecoderDerivationTest.scala
+++ b/json/src/test/scala/busymachines/json_test/derive/JsonDefaultSemiAutoDecoderDerivationTest.scala
@@ -1,12 +1,11 @@
-package busymachines.json_test.semiauto
+package busymachines.json_test.derive
 
 import busymachines.json_test._
 import org.scalatest.FlatSpec
 
 
 /**
-  *
-  * Here we test [[busymachines.json.Encoder]] derivation
+  * Here we test [[busymachines.json.Decoder]] derivation
   *
   * See the [[Melon]] hierarchy
   *
@@ -14,18 +13,16 @@ import org.scalatest.FlatSpec
   * @since 09 Aug 2017
   *
   */
-class JsonDefaultSemiAutoEncoderDerivationTest extends FlatSpec {
+class JsonDefaultSemiAutoDecoderDerivationTest extends FlatSpec {
 
   import busymachines.json.syntax._
-  import melonsDefaultSemiAutoEncoders._
+  import melonsDefaultSemiAutoDecoders._
 
   //-----------------------------------------------------------------------------------------------
 
-  it should "... be able to serialize anarchist melon (i.e. not part of any hierarchy)" in {
+  it should "... be able to deserialize anarchist melon (i.e. not part of any hierarchy)" in {
     val anarchistMelon = AnarchistMelon(noGods = true, noMasters = true, noSuperTypes = true)
-    val rawJson = anarchistMelon.asJson.spaces2
-
-    assertResult(
+    val rawJson =
       """
         |{
         |  "noGods" : true,
@@ -33,28 +30,28 @@ class JsonDefaultSemiAutoEncoderDerivationTest extends FlatSpec {
         |  "noSuperTypes" : true
         |}
       """.stripMargin.trim
-    )(rawJson)
+
+    val read = rawJson.unsafeDecodeAs[AnarchistMelon]
+    assertResult(anarchistMelon)(read)
   }
 
 
   //-----------------------------------------------------------------------------------------------
 
-  it should "... fail to compile when there is no defined encoder for a type down in the hierarchy" in {
+  it should "... fail to compile when there is no explicitly defined decoder for a type down in the hierarchy" in {
     assertDoesNotCompile(
       """
-        |val winterMelon: WinterMelon = WinterMelon(fuzzy = true, weight = 45)
-        |winterMelon.asJson
+        |val rawJson = "{}"
+        |rawJson.unsafeDecodeAs[WinterMelon]
       """.stripMargin
     )
   }
 
   //-----------------------------------------------------------------------------------------------
 
-  it should "... be able to serialize case class from hierarchy when it is referred to as its super-type" in {
+  it should "... be able to deserialize case class from hierarchy when it is referred to as its super-type" in {
     val winterMelon: Melon = WinterMelon(fuzzy = true, weight = 45)
-    val rawJson = winterMelon.asJson.spaces2
-
-    assertResult(
+    val rawJson =
       """
         |{
         |  "fuzzy" : true,
@@ -62,50 +59,51 @@ class JsonDefaultSemiAutoEncoderDerivationTest extends FlatSpec {
         |  "_type" : "WinterMelon"
         |}
       """.stripMargin.trim
-    )(rawJson)
+
+    val read = rawJson.unsafeDecodeAs[Melon]
+    assertResult(winterMelon)(read)
   }
 
   //-----------------------------------------------------------------------------------------------
 
-  it should "... be able to serialize case objects of the hierarchy" in {
+  it should "... be able to deserialize case objects of the hierarchy" in {
     val smallMelon: Melon = SmallMelon
-    val rawJson = smallMelon.asJson.spaces2
-    assertResult(
+    val rawJson =
       """
         |{
         |  "_type" : "SmallMelon"
         |}
       """.stripMargin.trim
-    )(rawJson)
+    val read = rawJson.unsafeDecodeAs[Melon]
+    assertResult(smallMelon)(read)
   }
 
   //-----------------------------------------------------------------------------------------------
 
-  it should "... serialize hierarchies of case objects as enums (i.e. plain strings)" in {
+  it should "... deserialize hierarchies of case objects as enums (i.e. plain strings)" in {
     val taste: List[Taste] = List(SweetTaste, SourTaste)
-
-    val rawJson = taste.asJson.spaces2
-    assertResult(
+    val rawJson =
       """
         |[
         |  "SweetTaste",
         |  "SourTaste"
         |]
       """.stripMargin.trim
-    )(rawJson)
+
+    val read = rawJson.unsafeDecodeAs[List[Taste]]
+    assertResult(read)(taste)
   }
 
   //-----------------------------------------------------------------------------------------------
 
-  it should "... serialize list of all case classes from the hierarchy" in {
+  it should "... deserialize list of all case classes from the hierarchy" in {
     val winterMelon: Melon = WinterMelon(fuzzy = true, weight = 45)
     val waterMelon: Melon = WaterMelon(seeds = true, weight = 90)
     val smallMelon: Melon = SmallMelon
     val squareMelon: Melon = SquareMelon(weight = 10, tastes = Seq(SourTaste, SweetTaste))
     val melons = List[Melon](winterMelon, waterMelon, smallMelon, squareMelon)
 
-    val rawJson = melons.asJson.spaces2
-    assertResult(
+    val rawJson =
       """
         |
         |[
@@ -132,9 +130,12 @@ class JsonDefaultSemiAutoEncoderDerivationTest extends FlatSpec {
         |  }
         |]
         |
-      """.stripMargin.trim
-    )(rawJson)
+        """.stripMargin.trim
+
+    val read: List[Melon] = rawJson.unsafeDecodeAs[List[Melon]]
+    assertResult(melons)(read)
   }
+
   //-----------------------------------------------------------------------------------------------
 
   //-----------------------------------------------------------------------------------------------

--- a/json/src/test/scala/busymachines/json_test/derive/JsonDefaultSemiAutoEncoderDerivationTest.scala
+++ b/json/src/test/scala/busymachines/json_test/derive/JsonDefaultSemiAutoEncoderDerivationTest.scala
@@ -1,11 +1,12 @@
-package busymachines.json_test.semiauto
+package busymachines.json_test.derive
 
 import busymachines.json_test._
 import org.scalatest.FlatSpec
 
 
 /**
-  * Here we test [[busymachines.json.Decoder]] derivation
+  *
+  * Here we test [[busymachines.json.Encoder]] derivation
   *
   * See the [[Melon]] hierarchy
   *
@@ -13,16 +14,18 @@ import org.scalatest.FlatSpec
   * @since 09 Aug 2017
   *
   */
-class JsonDefaultSemiAutoDecoderDerivationTest extends FlatSpec {
+class JsonDefaultSemiAutoEncoderDerivationTest extends FlatSpec {
 
   import busymachines.json.syntax._
-  import melonsDefaultSemiAutoDecoders._
+  import melonsDefaultSemiAutoEncoders._
 
   //-----------------------------------------------------------------------------------------------
 
-  it should "... be able to deserialize anarchist melon (i.e. not part of any hierarchy)" in {
+  it should "... be able to serialize anarchist melon (i.e. not part of any hierarchy)" in {
     val anarchistMelon = AnarchistMelon(noGods = true, noMasters = true, noSuperTypes = true)
-    val rawJson =
+    val rawJson = anarchistMelon.asJson.spaces2
+
+    assertResult(
       """
         |{
         |  "noGods" : true,
@@ -30,28 +33,28 @@ class JsonDefaultSemiAutoDecoderDerivationTest extends FlatSpec {
         |  "noSuperTypes" : true
         |}
       """.stripMargin.trim
-
-    val read = rawJson.unsafeDecodeAs[AnarchistMelon]
-    assertResult(anarchistMelon)(read)
+    )(rawJson)
   }
 
 
   //-----------------------------------------------------------------------------------------------
 
-  it should "... fail to compile when there is no explicitly defined decoder for a type down in the hierarchy" in {
+  it should "... fail to compile when there is no defined encoder for a type down in the hierarchy" in {
     assertDoesNotCompile(
       """
-        |val rawJson = "{}"
-        |rawJson.unsafeDecodeAs[WinterMelon]
+        |val winterMelon: WinterMelon = WinterMelon(fuzzy = true, weight = 45)
+        |winterMelon.asJson
       """.stripMargin
     )
   }
 
   //-----------------------------------------------------------------------------------------------
 
-  it should "... be able to deserialize case class from hierarchy when it is referred to as its super-type" in {
+  it should "... be able to serialize case class from hierarchy when it is referred to as its super-type" in {
     val winterMelon: Melon = WinterMelon(fuzzy = true, weight = 45)
-    val rawJson =
+    val rawJson = winterMelon.asJson.spaces2
+
+    assertResult(
       """
         |{
         |  "fuzzy" : true,
@@ -59,51 +62,50 @@ class JsonDefaultSemiAutoDecoderDerivationTest extends FlatSpec {
         |  "_type" : "WinterMelon"
         |}
       """.stripMargin.trim
-
-    val read = rawJson.unsafeDecodeAs[Melon]
-    assertResult(winterMelon)(read)
+    )(rawJson)
   }
 
   //-----------------------------------------------------------------------------------------------
 
-  it should "... be able to deserialize case objects of the hierarchy" in {
+  it should "... be able to serialize case objects of the hierarchy" in {
     val smallMelon: Melon = SmallMelon
-    val rawJson =
+    val rawJson = smallMelon.asJson.spaces2
+    assertResult(
       """
         |{
         |  "_type" : "SmallMelon"
         |}
       """.stripMargin.trim
-    val read = rawJson.unsafeDecodeAs[Melon]
-    assertResult(smallMelon)(read)
+    )(rawJson)
   }
 
   //-----------------------------------------------------------------------------------------------
 
-  it should "... deserialize hierarchies of case objects as enums (i.e. plain strings)" in {
+  it should "... serialize hierarchies of case objects as enums (i.e. plain strings)" in {
     val taste: List[Taste] = List(SweetTaste, SourTaste)
-    val rawJson =
+
+    val rawJson = taste.asJson.spaces2
+    assertResult(
       """
         |[
         |  "SweetTaste",
         |  "SourTaste"
         |]
       """.stripMargin.trim
-
-    val read = rawJson.unsafeDecodeAs[List[Taste]]
-    assertResult(read)(taste)
+    )(rawJson)
   }
 
   //-----------------------------------------------------------------------------------------------
 
-  it should "... deserialize list of all case classes from the hierarchy" in {
+  it should "... serialize list of all case classes from the hierarchy" in {
     val winterMelon: Melon = WinterMelon(fuzzy = true, weight = 45)
     val waterMelon: Melon = WaterMelon(seeds = true, weight = 90)
     val smallMelon: Melon = SmallMelon
     val squareMelon: Melon = SquareMelon(weight = 10, tastes = Seq(SourTaste, SweetTaste))
     val melons = List[Melon](winterMelon, waterMelon, smallMelon, squareMelon)
 
-    val rawJson =
+    val rawJson = melons.asJson.spaces2
+    assertResult(
       """
         |
         |[
@@ -130,12 +132,9 @@ class JsonDefaultSemiAutoDecoderDerivationTest extends FlatSpec {
         |  }
         |]
         |
-        """.stripMargin.trim
-
-    val read: List[Melon] = rawJson.unsafeDecodeAs[List[Melon]]
-    assertResult(melons)(read)
+      """.stripMargin.trim
+    )(rawJson)
   }
-
   //-----------------------------------------------------------------------------------------------
 
   //-----------------------------------------------------------------------------------------------

--- a/json/src/test/scala/busymachines/json_test/derive/JsonUtilsTest.scala
+++ b/json/src/test/scala/busymachines/json_test/derive/JsonUtilsTest.scala
@@ -1,4 +1,4 @@
-package busymachines.json_test.semiauto
+package busymachines.json_test.derive
 
 import busymachines.json.{JsonDecoding, JsonDecodingFailure, JsonParsing, JsonParsingFailure}
 import busymachines.json_test.AnarchistMelon

--- a/json/src/test/scala/busymachines/json_test/derive/semiAutoMelonJsonCodec.scala
+++ b/json/src/test/scala/busymachines/json_test/derive/semiAutoMelonJsonCodec.scala
@@ -1,4 +1,4 @@
-package busymachines.json_test.semiauto
+package busymachines.json_test.derive
 
 import busymachines.json_test._
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   //=================================== http://busymachines.com/ ===============================
   //========================================  busymachines =====================================
   //============================================================================================
-  lazy val bmCommonsVersion: String = "0.2.0-RC2"
+  lazy val bmCommonsVersion: String = "0.2.0-RC3"
 
   lazy val busymachinesCommonsCore: ModuleID = "com.busymachines" %% "busymachines-commons-core" % bmCommonsVersion withSources()
   lazy val busymachinesCommonsJson: ModuleID = "com.busymachines" %% "busymachines-commons-json" % bmCommonsVersion withSources()

--- a/rest-core-testkit/README.md
+++ b/rest-core-testkit/README.md
@@ -2,8 +2,8 @@
 
 ## artifacts
 
-Current version is `0.2.0-RC2`. SBT module id:
-`"com.busymachines" %% "busymachines-commons-rest-core-testkit" % "0.2.0-RC2" % test`
+Current version is `0.2.0-RC3`. SBT module id:
+`"com.busymachines" %% "busymachines-commons-rest-core-testkit" % "0.2.0-RC3" % test`
 
 N.B. that this is a testing library, and you should only depend on it in test. Because otherwise you wind up with scalatest and akka http testing libraries on your runtime classpath.
 

--- a/rest-core-testkit/src/main/scala/busymachines/rest/restTestkitHelpers.scala
+++ b/rest-core-testkit/src/main/scala/busymachines/rest/restTestkitHelpers.scala
@@ -1,7 +1,6 @@
 package busymachines.rest
 
 import akka.http.scaladsl.marshalling.ToEntityMarshaller
-import akka.http.scaladsl.model.{ContentType, ContentTypes}
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.server.RouteResult
 import akka.http.scaladsl.server.RouteResult.{Complete, Rejected}

--- a/rest-core/README.md
+++ b/rest-core/README.md
@@ -2,8 +2,8 @@
 
 ## artifacts
 
-Current version is `0.2.0-RC2`. SBT module id:
-`"com.busymachines" %% "busymachines-commons-rest-core" % "0.2.0-RC2"`
+Current version is `0.2.0-RC3`. SBT module id:
+`"com.busymachines" %% "busymachines-commons-rest-core" % "0.2.0-RC3"`
 
 ### Transitive dependencies
 - busymachines-commons-core

--- a/rest-core/src/main/scala/busymachines/rest/RestAPI.scala
+++ b/rest-core/src/main/scala/busymachines/rest/RestAPI.scala
@@ -100,7 +100,9 @@ object RestAPI {
     */
   def seal(api: RestAPI, apis: RestAPI*)(implicit
     routingSettings: RoutingSettings,
+    parserSettings:   ParserSettings   = null,
     rejectionHandler: RejectionHandler = RejectionHandler.default,
+    exceptionHandler: ExceptionHandler = null
   ): RestAPI = {
     val r = combine(api, apis: _ *)
     val sealedRoute = Route.seal(r.route)

--- a/rest-core/src/main/scala/busymachines/rest/package.scala
+++ b/rest-core/src/main/scala/busymachines/rest/package.scala
@@ -40,6 +40,10 @@ package object rest {
   val StatusCode: model.StatusCode.type = model.StatusCode
   val StatusCodes: model.StatusCodes.type = model.StatusCodes
 
+  type ContentType = model.ContentType
+  val ContentType: model.ContentType.type = model.ContentType
+  val ContentTypes: model.ContentTypes.type = model.ContentTypes
+
   type RoutingSettings = settings.RoutingSettings
   val RoutingSettings: settings.RoutingSettings.type = settings.RoutingSettings
 

--- a/rest-core/src/main/scala/busymachines/rest/package.scala
+++ b/rest-core/src/main/scala/busymachines/rest/package.scala
@@ -21,6 +21,9 @@ package object rest {
   type HttpResponse = model.HttpResponse
   val HttpResponse: model.HttpResponse.type = model.HttpResponse
 
+  type HttpEntity = model.HttpEntity
+  val HttpEntity: model.HttpEntity.type = model.HttpEntity
+
   type Route = server.Route
   val Route: server.Route.type = server.Route
 

--- a/rest-core/src/main/scala/busymachines/rest/package.scala
+++ b/rest-core/src/main/scala/busymachines/rest/package.scala
@@ -39,4 +39,7 @@ package object rest {
 
   type RoutingSettings = settings.RoutingSettings
   val RoutingSettings: settings.RoutingSettings.type = settings.RoutingSettings
+
+  type ParserSettings = akka.http.scaladsl.settings.ParserSettings
+  val ParserSettings: akka.http.scaladsl.settings.ParserSettings.type = akka.http.scaladsl.settings.ParserSettings
 }

--- a/rest-core/src/main/scala/busymachines/rest/restAPIAuthentication.scala
+++ b/rest-core/src/main/scala/busymachines/rest/restAPIAuthentication.scala
@@ -27,23 +27,23 @@ trait RestAPIAuthentication[AuthenticationResult] {
 @SubjectToChange("0.3.0")
 object RestAPIAuthentications {
 
-  val BasicS: String = "Basic"
-  val BearerS: String = "Bearer"
-  val AuthorizationS: String = "Authorization"
+  private val BasicS = "Basic"
+  private val BearerS = "Bearer"
+  private val AuthorizationS = "Authorization"
 
-  final val MissingBasicCredentials = AuthenticationFailedRejection(
+  private val MissingBasicCredentials = AuthenticationFailedRejection(
     cause = AuthenticationFailedRejection.CredentialsMissing,
     challenge = HttpChallenges.basic(BasicS))
 
-  final val InvalidBasicCredentials = AuthenticationFailedRejection(
+  private val InvalidBasicCredentials = AuthenticationFailedRejection(
     cause = AuthenticationFailedRejection.CredentialsRejected,
     challenge = HttpChallenges.basic(BasicS))
 
-  final val MissingBearerCredentials = AuthenticationFailedRejection(
+  private val MissingBearerCredentials = AuthenticationFailedRejection(
     cause = AuthenticationFailedRejection.CredentialsMissing,
     challenge = HttpChallenges.oAuth2(BearerS))
 
-  final val InvalidBearerCredentials = AuthenticationFailedRejection(
+  private val InvalidBearerCredentials = AuthenticationFailedRejection(
     cause = AuthenticationFailedRejection.CredentialsRejected,
     challenge = HttpChallenges.oAuth2(BasicS))
 

--- a/rest-json-testkit/README.md
+++ b/rest-json-testkit/README.md
@@ -2,8 +2,8 @@
 
 ## artifacts
 
-Current version is `0.2.0-RC2`. SBT module id:
-`"com.busymachines" %% "busymachines-commons-rest-json-testkit" % "0.2.0-RC2" % test`
+Current version is `0.2.0-RC3`. SBT module id:
+`"com.busymachines" %% "busymachines-commons-rest-json-testkit" % "0.2.0-RC3" % test`
 
 N.B. that this is a testing library, and you should only depend on it in test. Because otherwise you wind up with scalatest and akka http testing libraries on your runtime classpath.
 

--- a/rest-json-testkit/src/main/scala/busymachines/rest/jsonRestAPITest.scala
+++ b/rest-json-testkit/src/main/scala/busymachines/rest/jsonRestAPITest.scala
@@ -2,6 +2,9 @@ package busymachines.rest
 
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.scalatest.{Assertions, Suite}
+import busymachines.json._
+import busymachines.json.syntax._
+
 
 /**
   *
@@ -9,7 +12,11 @@ import org.scalatest.{Assertions, Suite}
   * @since 19 Oct 2017
   *
   */
-trait JsonRestAPITest extends RestAPITest with JsonRequestRunners with jsonrest.JsonSupport {
+trait JsonRestAPITest extends
+  RestAPITest with
+  JsonRequestRunners with
+  JsonRestAPIRequestBuildingSugar with
+  jsonrest.JsonSupport {
   this: Suite with Assertions =>
   debug()
 }
@@ -22,7 +29,29 @@ private[rest] trait JsonRequestRunners extends DefaultRequestRunners {
   override protected def transformEntityString(entityString: String): String = {
     JsonParsing.parseString(entityString) match {
       case Left(_) => entityString
-      case Right(value) => PrettyJson.spaces2NoNulls.pretty(value)
+      case Right(value) => value.spaces2NoNulls
     }
+  }
+}
+
+private[rest] trait JsonRestAPIRequestBuildingSugar extends RestAPIRequestBuildingSugar{
+  this: ScalatestRouteTest =>
+
+  protected def postJson[R](uri: String)(raw: Json)(thunk: => R)
+    (implicit cc: CallerContext): R = {
+    val g = Post(uri).withEntity(ContentTypes.`application/json`, raw.spaces2NoNulls)
+    requestRunner.runRequest(g)(thunk)
+  }
+
+  protected def patchJson[R](uri: String)(raw: Json)(thunk: => R)
+    (implicit cc: CallerContext): R = {
+    val g = Patch(uri).withEntity(ContentTypes.`application/json`, raw.spaces2NoNulls)
+    requestRunner.runRequest(g)(thunk)
+  }
+
+  protected def putJson[R](uri: String)(raw: Json)(thunk: => R)
+    (implicit cc: CallerContext): R = {
+    val g = Put(uri).withEntity(ContentTypes.`application/json`, raw.spaces2NoNulls)
+    requestRunner.runRequest(g)(thunk)
   }
 }

--- a/rest-json-testkit/src/test/scala/busymachines/rest_json_test/CRUDRoutesTest.scala
+++ b/rest-json-testkit/src/test/scala/busymachines/rest_json_test/CRUDRoutesTest.scala
@@ -63,35 +63,83 @@ private[rest_json_test] class CRUDRoutesTest extends ExampleRestAPITestBaseClass
       "lalala",
       None
     )
-    post("/crud", p) {
-      assert {
-        responseAs[SomeTestDTOGet] ==
-          SomeTestDTOGet(
-            42,
-            "lalala",
-            None
-          )
+
+    withClue("... typed post") {
+      post("/crud", p) {
+        assert {
+          responseAs[SomeTestDTOGet] ==
+            SomeTestDTOGet(
+              42,
+              "lalala",
+              None
+            )
+        }
       }
     }
+
+    withClue("... raw post") {
+      postRaw("/crud")(
+        """
+          |{
+          |  "string" : "lalala"
+          |}
+        """.stripMargin
+      ) {
+        assert {
+          responseAs[SomeTestDTOGet] ==
+            SomeTestDTOGet(
+              42,
+              "lalala",
+              None
+            )
+        }
+      }
+    }
+
   }
 
   //===========================================================================
 
   it should "return 200 OK on PUT" in {
     val p = SomeTestDTOPut(
-      "lalala",
-      Option(42)
+      string = "lalala",
+      option = Option(42)
     )
-    put("/crud/77", p) {
-      expectStatus(StatusCodes.OK)
 
-      assert {
-        responseAs[SomeTestDTOGet] ==
-          SomeTestDTOGet(
-            77,
-            "lalala",
-            Option(42)
-          )
+    withClue("... typed PUT") {
+      put("/crud/77", p) {
+        expectStatus(StatusCodes.OK)
+
+        assert {
+          responseAs[SomeTestDTOGet] ==
+            SomeTestDTOGet(
+              77,
+              "lalala",
+              Option(42)
+            )
+        }
+      }
+    }
+
+    withClue("... raw PUT") {
+      putRaw("/crud/77")(
+        """
+          |{
+          |  "string" : "lalala",
+          |  "option" : "42"
+          |}
+        """.stripMargin
+      ) {
+        expectStatus(StatusCodes.OK)
+
+        assert {
+          responseAs[SomeTestDTOGet] ==
+            SomeTestDTOGet(
+              77,
+              "lalala",
+              Option(42)
+            )
+        }
       }
     }
   }
@@ -102,16 +150,40 @@ private[rest_json_test] class CRUDRoutesTest extends ExampleRestAPITestBaseClass
     val p = SomeTestDTOPatch(
       "lalala"
     )
-    patch("/crud/77", p) {
-      expectStatus(StatusCodes.OK)
 
-      assert {
-        responseAs[SomeTestDTOGet] ==
-          SomeTestDTOGet(
-            77,
-            "lalala",
-            None
-          )
+    withClue("... typed PATCH") {
+      patch("/crud/77", p) {
+        expectStatus(StatusCodes.OK)
+
+        assert {
+          responseAs[SomeTestDTOGet] ==
+            SomeTestDTOGet(
+              77,
+              "lalala",
+              None
+            )
+        }
+      }
+    }
+
+    withClue("... raw PATCH") {
+      patchRaw("/crud/77")(
+        """
+          |{
+          |  "string" : "lalala"
+          |}
+        """.stripMargin
+      ) {
+        expectStatus(StatusCodes.OK)
+
+        assert {
+          responseAs[SomeTestDTOGet] ==
+            SomeTestDTOGet(
+              77,
+              "lalala",
+              None
+            )
+        }
       }
     }
   }

--- a/rest-json/README.md
+++ b/rest-json/README.md
@@ -2,8 +2,8 @@
 
 ## artifacts
 
-Current version is `0.2.0-RC2`. SBT module id:
-`"com.busymachines" %% "busymachines-commons-rest-json" % "0.2.0-RC2"`
+Current version is `0.2.0-RC3`. SBT module id:
+`"com.busymachines" %% "busymachines-commons-rest-json" % "0.2.0-RC3"`
 
 ### Transitive dependencies
 - busymachines-commons-core

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.0-RC2"
+version in ThisBuild := "0.2.0-RC3"


### PR DESCRIPTION
- [x] align types of `RestAPI.seal` and `akka....Routes.seal`. This way `RestAPI` retain maximum flexibility
- [x] add `{post/put/patch}Raw` methods in the scope `RestAPITest`. So you can create requests without any-kind of a Marshaller, but benefiting from the full flexibility of the test DSL
- [x] add similar methods but with `json` prefix in `JsonRestAPITest`, but which accept only types `Json`.
- [x] add aliases to `ContentType` in `busymachines.rest`