### PR TITLE
Feature/semver

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ These modules are are cross-compiled for Scala versions: `2.12.3`. We try our be
   * [README.md](/rest-json-testkit) [![Maven Central](https://img.shields.io/maven-central/v/com.busymachines/busymachines-commons-rest-json-testkit_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.busymachines/busymachines-commons-rest-json-testkit_2.12)
 * `"com.busymachines" %% "busymachines-commons-semver" % "0.2.0-RC6"`
   * [README.md](/semver) [![Maven Central](https://img.shields.io/maven-central/v/com.busymachines/busymachines-commons-semver_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.busymachines/busymachines-commons-semver_2.12)  
-* `"com.busymachines" %% "busymachines-commons-semver-parsers" % "0.2.0-RC6"`
-  [README.md](/semver-parsers) [![Maven Central](https://img.shields.io/maven-central/v/com.busymachines/busymachines-commons-semver-parsers_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.busymachines/busymachines-commons-semver-parsers_2.12)
+* `"com.busymachines" %% "busymachines-commons-semver-parsers" % "0.2.0-RC6"`  
+  * [README.md](/semver-parsers) [![Maven Central](https://img.shields.io/maven-central/v/com.busymachines/busymachines-commons-semver-parsers_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.busymachines/busymachines-commons-semver-parsers_2.12)
 
 ##### deprecated:
 This is a parallel module hierarchy whose json serialization is handled by `spray-json`. DO NOT use together with their non-deprecated counterpart. These will not live very long, use at your own risk. The same design rules were followed, and the `rest` packages are syntactically, and semantically almost identical to the non-deprecated counterparts. Using the `json` package differs the most.
@@ -51,27 +51,31 @@ This is a parallel module hierarchy whose json serialization is handled by `spra
 * `"com.busymachines" %% "busymachines-commons-json-spray" % "0.2.0-RC6"`
   * [README.md](/json-spray) [![Maven Central](https://img.shields.io/maven-central/v/com.busymachines/busymachines-commons-json-spray_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.busymachines/busymachines-commons-json-spray_2.12)
 * `"com.busymachines" %% "busymachines-commons-rest-json-spray" % "0.2.0-RC6"`
-  * [README.md](/rest-json-spray) [![Maven Central](https://img.shields.io/maven-central/v/com.busymachines/busymachines-commons-rest-json-spray_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.busymachines/busymachines-commons-rest-json-spray_2.12)
+  * [README.md](/rest-json-spray) [![Maven Central](https://img.shields.io/maven-central/v/com.busymachines/busymachines-commons-rest-json-spray_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.busymachines/busymachines-commons-rest-json-spray_2.12)  
 * `"com.busymachines" %% "busymachines-commons-rest-json-spray-testkit" % "0.2.0-RC6" % Test`
   * [README.md](/rest-json-spray-testkit) [![Maven Central](https://img.shields.io/maven-central/v/com.busymachines/busymachines-commons-rest-json-spray-testkit_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.busymachines/busymachines-commons-rest-json-spray-testkit_2.12)
 
 For easy copy-pasting:
 ```scala
-lazy val bmcVersion: String = "0.2.0-RC6"
+val bmcVersion: String = "0.2.0-RC6"
 
-lazy val bmcCore = "com.busymachines" %% "busymachines-commons-core" % bmcVersion
-lazy val bmcJson = "com.busymachines" %% "busymachines-commons-json" % bmcVersion
-lazy val bmcRestCore = "com.busymachines" %% "busymachines-commons-rest-core" % bmcVersion
-lazy val bmcRestCoreTestkit = "com.busymachines" %% "busymachines-commons-rest-core-testkit" % bmcVersion % Test
-lazy val bmcRestJson = "com.busymachines" %% "busymachines-commons-rest-json" % bmcVersion
-lazy val bmcRestJsonTestkit = "com.busymachines" %% "busymachines-commons-rest-json-testkit" % bmcVersion % Test
+val bmcCore            = "com.busymachines" %% "busymachines-commons-core" % bmcVersion
+val bmcJson            = "com.busymachines" %% "busymachines-commons-json" % bmcVersion
+val bmcRestCore        = "com.busymachines" %% "busymachines-commons-rest-core" % bmcVersion
+val bmcRestCoreTestkit = "com.busymachines" %% "busymachines-commons-rest-core-testkit" % bmcVersion % Test
+val bmcRestJson        = "com.busymachines" %% "busymachines-commons-rest-json" % bmcVersion
+val bmcRestJsonTestkit = "com.busymachines" %% "busymachines-commons-rest-json-testkit" % bmcVersion % Test
+
+val bmcSemVer         = "com.busymachines" %% "busymachines-commons-semver" % bmcVersion
+val bmcSemVerParsers  = "com.busymachines" %% "busymachines-commons-semver-parsers" % bmcVersion
 
 @scala.deprecated("use json module instead", "0.2.0")
-lazy val bmJsonSpray = "com.busymachines" %% "busymachines-commons-json-spray" % bmcVersion
+val bmcJsonSpray = "com.busymachines" %% "busymachines-commons-json-spray" % bmcVersion
 @scala.deprecated("use rest-json module instead", "0.2.0")
-lazy val bmRestJsonSpray = "com.busymachines" %% "busymachines-commons-rest-json-spray" % bmcVersion
+val bmcRestJsonSpray = "com.busymachines" %% "busymachines-commons-rest-json-spray" % bmcVersion
 @scala.deprecated("use rest-json-testkit module instead", "0.2.0")
-lazy val bmRestJsonSprayTestkit = "com.busymachines" %% "busymachines-commons-rest-json-spray-testkit" % bmcVersion % Test
+val bmcRestJsonSprayTestkit = "com.busymachines" %% "busymachines-commons-rest-json-spray-testkit" % bmcVersion % Test
+
 ```
 
 ## Library Structure

--- a/README.md
+++ b/README.md
@@ -23,37 +23,37 @@ Probably due to an missing implicit — probably automatic derivation of some ty
 
 #### versions
 * stable: `0.1.0` — but almost useless
-* latest: `0.2.0-RC5`
+* latest: `0.2.0-RC6`
 
 These modules are are cross-compiled for Scala versions: `2.12.3`. We try our best to keep them up to date.
 
 #### Modules:
-* `"com.busymachines" %% "busymachines-commons-core" % "0.2.0-RC5"`
+* `"com.busymachines" %% "busymachines-commons-core" % "0.2.0-RC6"`
   * [README.md](/core) [![Maven Central](https://img.shields.io/maven-central/v/com.busymachines/busymachines-commons-core_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.busymachines/busymachines-commons-core_2.12)
-* `"com.busymachines" %% "busymachines-commons-json" % "0.2.0-RC5"`
+* `"com.busymachines" %% "busymachines-commons-json" % "0.2.0-RC6"`
   * [README.md](/json) [![Maven Central](https://img.shields.io/maven-central/v/com.busymachines/busymachines-commons-json_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.busymachines/busymachines-commons-json_2.12)
-* `"com.busymachines" %% "busymachines-commons-rest-core" % "0.2.0-RC5"`
+* `"com.busymachines" %% "busymachines-commons-rest-core" % "0.2.0-RC6"`
   * [README.md](/rest-core) [![Maven Central](https://img.shields.io/maven-central/v/com.busymachines/busymachines-commons-rest-core_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.busymachines/busymachines-commons-rest-core_2.12)
-* `"com.busymachines" %% "busymachines-commons-rest-core-testkit" % "0.2.0-RC5" % Test`
+* `"com.busymachines" %% "busymachines-commons-rest-core-testkit" % "0.2.0-RC6" % Test`
   * [README.md](/rest-core-testkit) [![Maven Central](https://img.shields.io/maven-central/v/com.busymachines/busymachines-commons-rest-core-testkit_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.busymachines/busymachines-commons-rest-core-testkit_2.12)
-* `"com.busymachines" %% "busymachines-commons-rest-json" % "0.2.0-RC5"`
+* `"com.busymachines" %% "busymachines-commons-rest-json" % "0.2.0-RC6"`
   * [README.md](/rest-json) [![Maven Central](https://img.shields.io/maven-central/v/com.busymachines/busymachines-commons-rest-json_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.busymachines/busymachines-commons-rest-json_2.12)
-* `"com.busymachines" %% "busymachines-commons-rest-json-testkit" % "0.2.0-RC5" % Test`
+* `"com.busymachines" %% "busymachines-commons-rest-json-testkit" % "0.2.0-RC6" % Test`
   * [README.md](/rest-json-testkit) [![Maven Central](https://img.shields.io/maven-central/v/com.busymachines/busymachines-commons-rest-json-testkit_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.busymachines/busymachines-commons-rest-json-testkit_2.12)
 
 ##### deprecated:
 This is a parallel module hierarchy whose json serialization is handled by `spray-json`. DO NOT use together with their non-deprecated counterpart. These will not live very long, use at your own risk. The same design rules were followed, and the `rest` packages are syntactically, and semantically almost identical to the non-deprecated counterparts. Using the `json` package differs the most.
 
-* `"com.busymachines" %% "busymachines-commons-json-spray" % "0.2.0-RC5"`
+* `"com.busymachines" %% "busymachines-commons-json-spray" % "0.2.0-RC6"`
   * [README.md](/json-spray) [![Maven Central](https://img.shields.io/maven-central/v/com.busymachines/busymachines-commons-json-spray_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.busymachines/busymachines-commons-json-spray_2.12)
-* `"com.busymachines" %% "busymachines-commons-rest-json-spray" % "0.2.0-RC5"`
+* `"com.busymachines" %% "busymachines-commons-rest-json-spray" % "0.2.0-RC6"`
   * [README.md](/rest-json-spray) [![Maven Central](https://img.shields.io/maven-central/v/com.busymachines/busymachines-commons-rest-json-spray_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.busymachines/busymachines-commons-rest-json-spray_2.12)
-* `"com.busymachines" %% "busymachines-commons-rest-json-spray-testkit" % "0.2.0-RC5" % Test`
+* `"com.busymachines" %% "busymachines-commons-rest-json-spray-testkit" % "0.2.0-RC6" % Test`
   * [README.md](/rest-json-spray-testkit) [![Maven Central](https://img.shields.io/maven-central/v/com.busymachines/busymachines-commons-rest-json-spray-testkit_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.busymachines/busymachines-commons-rest-json-spray-testkit_2.12)
 
 For easy copy-pasting:
 ```scala
-lazy val bmcVersion: String = "0.2.0-RC5"
+lazy val bmcVersion: String = "0.2.0-RC6"
 
 lazy val bmcCore = "com.busymachines" %% "busymachines-commons-core" % bmcVersion
 lazy val bmcJson = "com.busymachines" %% "busymachines-commons-json" % bmcVersion
@@ -77,11 +77,11 @@ The idea behind these sets of libraries is to help jumpstart backend RESTful api
 Basically, as long as modules reside in the same repository they will be versioned with the same number, and released at the same time to avoid confusion. The moment we realize that a module has to take a life of its own, it will be moved to a separate module and versioned independently.
 
 * [core](/core) `0.1.0`
-* [json](/json) `0.2.0-RC5`
-* [rest-core](/rest-core) `0.2.0-RC5` - this is an abstract implementation that still requires specific serialization/deserialization
-* [rest-core-testkit](/rest-core-testkit) `0.2.0-RC5` - contains helpers that allow testing. Should never wind up in production code.
-* [rest-json](/rest-core) `0.2.0-RC5` - used to implement REST APIs that handle JSON
-* [rest-json-testkit](/rest-json-testkit) `0.2.0-RC5` - helpers for JSON powered REST APIs
+* [json](/json) `0.2.0-RC6`
+* [rest-core](/rest-core) `0.2.0-RC6` - this is an abstract implementation that still requires specific serialization/deserialization
+* [rest-core-testkit](/rest-core-testkit) `0.2.0-RC6` - contains helpers that allow testing. Should never wind up in production code.
+* [rest-json](/rest-core) `0.2.0-RC6` - used to implement REST APIs that handle JSON
+* [rest-json-testkit](/rest-json-testkit) `0.2.0-RC6` - helpers for JSON powered REST APIs
 
 
 Most likely you don't need to depend on the `rest-core*` modules. But rather on one or more of its reifications like `rest-json`. This separation was done because in the future we might need non-json REST APIs, and then we still want to have a common experience of using `commons`.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ These modules are are cross-compiled for Scala versions: `2.12.3`. We try our be
   * [README.md](/rest-json) [![Maven Central](https://img.shields.io/maven-central/v/com.busymachines/busymachines-commons-rest-json_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.busymachines/busymachines-commons-rest-json_2.12)
 * `"com.busymachines" %% "busymachines-commons-rest-json-testkit" % "0.2.0-RC6" % Test`
   * [README.md](/rest-json-testkit) [![Maven Central](https://img.shields.io/maven-central/v/com.busymachines/busymachines-commons-rest-json-testkit_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.busymachines/busymachines-commons-rest-json-testkit_2.12)
+* `"com.busymachines" %% "busymachines-commons-semver" % "0.2.0-RC6"`
+  * [README.md](/semver) [![Maven Central](https://img.shields.io/maven-central/v/com.busymachines/busymachines-commons-semver_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.busymachines/busymachines-commons-semver_2.12)  
+* `"com.busymachines" %% "busymachines-commons-semver-parsers" % "0.2.0-RC6"`
+  [README.md](/semver-parsers) [![Maven Central](https://img.shields.io/maven-central/v/com.busymachines/busymachines-commons-semver-parsers_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.busymachines/busymachines-commons-semver-parsers_2.12)
 
 ##### deprecated:
 This is a parallel module hierarchy whose json serialization is handled by `spray-json`. DO NOT use together with their non-deprecated counterpart. These will not live very long, use at your own risk. The same design rules were followed, and the `rest` packages are syntactically, and semantically almost identical to the non-deprecated counterparts. Using the `json` package differs the most.
@@ -83,8 +87,11 @@ Basically, as long as modules reside in the same repository they will be version
 * [rest-json](/rest-core) `0.2.0-RC6` - used to implement REST APIs that handle JSON
 * [rest-json-testkit](/rest-json-testkit) `0.2.0-RC6` - helpers for JSON powered REST APIs
 
-
 Most likely you don't need to depend on the `rest-core*` modules. But rather on one or more of its reifications like `rest-json`. This separation was done because in the future we might need non-json REST APIs, and then we still want to have a common experience of using `commons`.
+
+Other modules:
+* [semver](/semver) `0.2.0-RC6` - definition of a `SemanticVersion` datatype and its natural ordering according to the [Semantic Version 2.0.0](http://semver.org/) spec. Useful only if you have to manipulate semantic versions in your code. No other modules here depend on it.
+* [semver](/semver-parsers) `0.2.0-RC6` - parsers from plain string to the above `SemanticVersion`.
 
 ### Current version
 

--- a/build.sbt
+++ b/build.sbt
@@ -202,6 +202,4 @@ lazy val `semver` = project
       Dependencies.scalaTest % Test withSources()
     )
   )
-  .dependsOn(
-    core
-  )
+  .dependsOn()

--- a/build.sbt
+++ b/build.sbt
@@ -70,7 +70,7 @@ lazy val json = project
     core
   )
 
-@scala.deprecated("better use `json` module. This one is not part of the future roadmap of the library", "0.2.0-RC5")
+@scala.deprecated("better use `json` module. This one is not part of the future roadmap of the library", "0.2.0-RC6")
 lazy val `json-spray` = project
   .settings(Settings.commonSettings)
   .settings(PublishingSettings.sonatypeSettings)
@@ -144,7 +144,7 @@ lazy val `rest-json` = project
     `rest-core`,
   )
 
-@scala.deprecated("better use `rest-json` module. This one is not part of the future roadmap of the library", "0.2.0-RC5")
+@scala.deprecated("better use `rest-json` module. This one is not part of the future roadmap of the library", "0.2.0-RC6")
 lazy val `rest-json-spray` = project
   .settings(Settings.commonSettings)
   .settings(PublishingSettings.sonatypeSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -42,6 +42,7 @@ lazy val root = Project(
     `rest-json-spray-testkit`,
 
     `semver`,
+    `semver-parsers`,
   )
 
 lazy val core = project
@@ -165,7 +166,7 @@ lazy val `rest-json-testkit` = project
   .settings(
     name in ThisProject := "busymachines-commons-rest-json-testkit",
     libraryDependencies ++= Seq(
-      Dependencies.scalaTest % Test withSources()
+      Dependencies.scalaTest % Test withSources(),
     )
   )
   .dependsOn(
@@ -182,7 +183,7 @@ lazy val `rest-json-spray-testkit` = project
   .settings(
     name in ThisProject := "busymachines-commons-rest-json-spray-testkit",
     libraryDependencies ++= Seq(
-      Dependencies.scalaTest % Test withSources()
+      Dependencies.scalaTest % Test withSources(),
     )
   )
   .dependsOn(
@@ -199,7 +200,24 @@ lazy val `semver` = project
   .settings(
     name in ThisProject := "busymachines-commons-semver",
     libraryDependencies ++= Seq(
-      Dependencies.scalaTest % Test withSources()
+      Dependencies.scalaTest % Test withSources(),
     )
   )
   .dependsOn()
+
+lazy val `semver-parsers` = project
+  .settings(Settings.commonSettings)
+  .settings(PublishingSettings.sonatypeSettings)
+  .settings(
+    name in ThisProject := "busymachines-commons-semver-parsers",
+    libraryDependencies ++= Seq(
+      Dependencies.attoParser withSources(),
+
+      Dependencies.scalaTest % Test withSources(),
+      Dependencies.scalaCheck % Test withSources(),
+    )
+  )
+  .dependsOn(
+    core,
+    `semver`
+  )

--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,8 @@ lazy val root = Project(
     `json-spray`,
     `rest-json-spray`,
     `rest-json-spray-testkit`,
+
+    `semver`,
   )
 
 lazy val core = project
@@ -191,3 +193,15 @@ lazy val `rest-json-spray-testkit` = project
     `rest-core-testkit`,
   )
 
+lazy val `semver` = project
+  .settings(Settings.commonSettings)
+  .settings(PublishingSettings.sonatypeSettings)
+  .settings(
+    name in ThisProject := "busymachines-commons-semver",
+    libraryDependencies ++= Seq(
+      Dependencies.scalaTest % Test withSources()
+    )
+  )
+  .dependsOn(
+    core
+  )

--- a/core/README.md
+++ b/core/README.md
@@ -4,10 +4,10 @@
 
 ## artifacts
 
-This module is vanilla scala _*only*_, cross-compiled against versions: `2.12.4`.
+This module is vanilla scala _*only*_, cross-compiled against versions: `2.12.3`.
 
 The full module id is:
-`"com.busymachines" %% "busymachines-commons-core" % "0.2.0-RC5"`
+`"com.busymachines" %% "busymachines-commons-core" % "0.2.0-RC6"`
 
 ## Description
 

--- a/json-spray/README.md
+++ b/json-spray/README.md
@@ -4,8 +4,8 @@
 
 _*DO NOT DEPEND ON BOTH THIS MODULE AND `json`. They share the same packages. It will end badly, chose one or the other. THIS MODULE WILL RECEIVE WAY LESS ATTENTION THAN THE OTHERS, AND HAS A HIGH CHANCE OF BEING DROPPED*_
 
-Current version is `0.2.0-RC5`. SBT module id:
-`"com.busymachines" %% "busymachines-commons-json-spray" % "0.2.0-RC5"`
+Current version is `0.2.0-RC6`. SBT module id:
+`"com.busymachines" %% "busymachines-commons-json-spray" % "0.2.0-RC6"`
 
 You should really, really use the [`json`](../json/README.md) module instead. This one is simply a legacy implementation for supporting the now defunct `spray-json`.
 

--- a/json/README.md
+++ b/json/README.md
@@ -2,8 +2,8 @@
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.busymachines/busymachines-commons-json_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.busymachines/busymachines-commons-json_2.12)
 
-Current version is `0.2.0-RC5`. SBT module id:
-`"com.busymachines" %% "busymachines-commons-json" % "0.2.0-RC5"`
+Current version is `0.2.0-RC6`. SBT module id:
+`"com.busymachines" %% "busymachines-commons-json" % "0.2.0-RC6"`
 
 ## How it works
 This module is a thin layer over [circe](https://circe.github.io/circe/), additionally, it depends on [shapeless](https://github.com/milessabin/shapeless). The latter being the mechanism through which `autoderive` and `derive` derivation can be made to work.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,15 +17,17 @@ object Dependencies {
   //=================================== http://busymachines.com/ ===============================
   //========================================  busymachines =====================================
   //============================================================================================
-  lazy val bmCommonsVersion: String = "0.2.0-RC6"
+  lazy val bmcVersion: String = "0.2.0-RC6"
 
-  lazy val busymachinesCommonsCore: ModuleID = "com.busymachines" %% "busymachines-commons-core" % bmCommonsVersion withSources()
-  lazy val busymachinesCommonsJson: ModuleID = "com.busymachines" %% "busymachines-commons-json" % bmCommonsVersion withSources()
-  lazy val busymachinesCommonsRestCore: ModuleID = "com.busymachines" %% "busymachines-commons-rest-core" % bmCommonsVersion withSources()
-  lazy val busymachinesCommonsRestCoreTestkit: ModuleID = "com.busymachines" %% "busymachines-commons-rest-core-testkit" % bmCommonsVersion % Test withSources()
-  lazy val busymachinesCommonsRestJson: ModuleID = "com.busymachines" %% "busymachines-commons-rest-json" % bmCommonsVersion withSources()
-  lazy val busymachinesCommonsRestJsonTestkit: ModuleID = "com.busymachines" %% "busymachines-commons-rest-Json-testkit" % bmCommonsVersion % Test withSources()
+  lazy val bmcCore: ModuleID = "com.busymachines" %% "busymachines-commons-core" % bmcVersion
+  lazy val bmcJson: ModuleID = "com.busymachines" %% "busymachines-commons-json" % bmcVersion
+  lazy val bmcRestCore: ModuleID = "com.busymachines" %% "busymachines-commons-rest-core" % bmcVersion
+  lazy val bmcRestCoreTestkit: ModuleID = "com.busymachines" %% "busymachines-commons-rest-core-testkit" % bmcVersion % Test
+  lazy val bmcRestJson: ModuleID = "com.busymachines" %% "busymachines-commons-rest-json" % bmcVersion withSources()
+  lazy val bmcRestJsonTestkit: ModuleID = "com.busymachines" %% "busymachines-commons-rest-json-testkit" % bmcVersion % Test
 
+  lazy val bmcSemVer: ModuleID = "com.busymachines" %% "busymachines-commons-semver" % bmcVersion
+  lazy val bmcSemVerParsers: ModuleID = "com.busymachines" %% "busymachines-commons-semver-parsers" % bmcVersion
 
   //============================================================================================
   //================================= http://typelevel.org/scala/ ==============================

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -56,6 +56,8 @@ object Dependencies {
     circeParser
   )
 
+  lazy val attoParser: ModuleID = "org.tpolecat" %% "atto-core" % "0.6.1-M7"
+
   //============================================================================================
   //================================= http://akka.io/docs/ =====================================
   //======================================== akka ==============================================
@@ -89,7 +91,10 @@ object Dependencies {
   //============================================================================================
   //=========================================  testing =========================================
   //============================================================================================
+
   lazy val scalaTest: ModuleID = "org.scalatest" %% "scalatest" % "3.0.4"
+  lazy val scalaCheck: ModuleID = "org.scalacheck" %% "scalacheck" % "1.13.4"
+
 
   lazy val akkaTestKit: ModuleID = "com.typesafe.akka" %% "akka-testkit" % akkaVersion
   lazy val akkaStreamTestKit: ModuleID = "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   //=================================== http://busymachines.com/ ===============================
   //========================================  busymachines =====================================
   //============================================================================================
-  lazy val bmCommonsVersion: String = "0.2.0-RC5"
+  lazy val bmCommonsVersion: String = "0.2.0-RC6"
 
   lazy val busymachinesCommonsCore: ModuleID = "com.busymachines" %% "busymachines-commons-core" % bmCommonsVersion withSources()
   lazy val busymachinesCommonsJson: ModuleID = "com.busymachines" %% "busymachines-commons-json" % bmCommonsVersion withSources()
@@ -83,9 +83,9 @@ object Dependencies {
 
 
   lazy val sprayJsonVersion = "1.3.3"
-  @scala.deprecated("seriously, migrate to circe, and use the json module", "0.2.0-RC5")
+  @scala.deprecated("seriously, migrate to circe, and use the json module", "0.2.0-RC6")
   lazy val sprayJson: ModuleID = "io.spray" %% "spray-json" % sprayJsonVersion
-  @scala.deprecated("seriously, migrate to circe, and use the json module", "0.2.0-RC5")
+  @scala.deprecated("seriously, migrate to circe, and use the json module", "0.2.0-RC6")
   lazy val akkaHttpSprayJson: ModuleID = "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpVersion
 
   //============================================================================================

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -11,7 +11,14 @@ object Settings {
       organization in ThisBuild := organizationName,
       homepage := Some(url(bmCommonsHomepage)),
       scalaVersion := Dependencies.mainScalaVersion,
-      //      crossScalaVersions := Dependencies.seqOfCrossScalaVersions
+      //      crossScalaVersions := Dependencies.seqOfCrossScalaVersions,
+
+      /**
+        * akka http is binary compatible both with 2.5.4 (which we have), but it is openly dependent on 2.4.19
+        * that's why we can safely force our version in order to avoid those super annoying eviction warnings
+        */
+      dependencyOverrides += Dependencies.akkaStream,
+      dependencyOverrides += Dependencies.akkaActor,
     ) ++ scalaCompilerSettings
 
   def scalaCompilerSettings: Seq[Setting[_]] = Seq(

--- a/rest-core-testkit/README.md
+++ b/rest-core-testkit/README.md
@@ -4,8 +4,8 @@
 
 ## artifacts
 
-Current version is `0.2.0-RC5`. SBT module id:
-`"com.busymachines" %% "busymachines-commons-rest-core-testkit" % "0.2.0-RC5" % test`
+Current version is `0.2.0-RC6`. SBT module id:
+`"com.busymachines" %% "busymachines-commons-rest-core-testkit" % "0.2.0-RC6" % test`
 
 N.B. that this is a testing library, and you should only depend on it in test. Because otherwise you wind up with scalatest and akka http testing libraries on your runtime classpath.
 

--- a/rest-core/README.md
+++ b/rest-core/README.md
@@ -4,8 +4,8 @@
 
 ## artifacts
 
-Current version is `0.2.0-RC5`. SBT module id:
-`"com.busymachines" %% "busymachines-commons-rest-core" % "0.2.0-RC5"`
+Current version is `0.2.0-RC6`. SBT module id:
+`"com.busymachines" %% "busymachines-commons-rest-core" % "0.2.0-RC6"`
 
 ### Transitive dependencies
 - busymachines-commons-core

--- a/rest-json-spray-testkit/README.md
+++ b/rest-json-spray-testkit/README.md
@@ -6,8 +6,8 @@ _*DO NOT DEPEND ON BOTH THIS MODULE AND `rest-json-testkit`. They share the same
 
 ## artifacts
 
-Current version is `0.2.0-RC5`. SBT module id:
-`"com.busymachines" %% "busymachines-commons-rest-json-spray-testkit" % "0.2.0-RC5" % test`
+Current version is `0.2.0-RC6`. SBT module id:
+`"com.busymachines" %% "busymachines-commons-rest-json-spray-testkit" % "0.2.0-RC6" % test`
 
 ## usage
 It's literally the same as with [`rest-json-testkit`](../rest-json-testkit/README.md), you just need to have the corresponding JSON serializers/deserializers in scope for your tests, and that's it.

--- a/rest-json-spray/README.md
+++ b/rest-json-spray/README.md
@@ -4,8 +4,8 @@
 
 _*DO NOT DEPEND ON BOTH THIS MODULE AND `rest-json`. They share the same packages, and type names. It will end badly, chose one or the other. THIS MODULE WILL RECEIVE WAY LESS ATTENTION THAN THE OTHERS, AND HAS A HIGH CHANCE OF BEING DROPPED.*_
 
-Current version is `0.2.0-RC5`. SBT module id:
-`"com.busymachines" %% "busymachines-commons-rest-json-spray" % "0.2.0-RC5"`
+Current version is `0.2.0-RC6`. SBT module id:
+`"com.busymachines" %% "busymachines-commons-rest-json-spray" % "0.2.0-RC6"`
 
 You should really, really use the [`rest-json`](../rest-json-spray/README.md) module instead. This one is simply a legacy implementation for supporting the now defunct `spray-json`.
 

--- a/rest-json-testkit/README.md
+++ b/rest-json-testkit/README.md
@@ -4,8 +4,8 @@
 
 ## artifacts
 
-Current version is `0.2.0-RC5`. SBT module id:
-`"com.busymachines" %% "busymachines-commons-rest-json-testkit" % "0.2.0-RC5" % test`
+Current version is `0.2.0-RC6`. SBT module id:
+`"com.busymachines" %% "busymachines-commons-rest-json-testkit" % "0.2.0-RC6" % test`
 
 N.B. that this is a testing library, and you should only depend on it in test. Because otherwise you wind up with scalatest and akka http testing libraries on your runtime classpath.
 

--- a/rest-json/README.md
+++ b/rest-json/README.md
@@ -4,8 +4,8 @@
 
 ## artifacts
 
-Current version is `0.2.0-RC5`. SBT module id:
-`"com.busymachines" %% "busymachines-commons-rest-json" % "0.2.0-RC5"`
+Current version is `0.2.0-RC6`. SBT module id:
+`"com.busymachines" %% "busymachines-commons-rest-json" % "0.2.0-RC6"`
 
 ### Transitive dependencies
 - busymachines-commons-core

--- a/semver-parsers/README.md
+++ b/semver-parsers/README.md
@@ -4,10 +4,10 @@
 
 ## artifacts
 
-This module is vanilla scala _*only*_, cross-compiled against versions: `2.12.4`.
+This module is vanilla scala _*only*_, cross-compiled against versions: `2.12.3`.
 
 The full module id is:
-`"com.busymachines" %% "busymachines-commons-semver-parsers" % "0.2.0-RC5"`
+`"com.busymachines" %% "busymachines-commons-semver-parsers" % "0.2.0-RC6"`
 
 ### Transitive dependencies
 

--- a/semver-parsers/README.md
+++ b/semver-parsers/README.md
@@ -12,8 +12,8 @@ The full module id is:
 ### Transitive dependencies
 
 * [`core`](../core/README.md)
-* `atto` — parsing library
- * `cats`
+* [`atto`](https://github.com/tpolecat/atto) — parsing library
+  * [`cats`](https://github.com/typelevel/cats)
 
 ## Description
 

--- a/semver-parsers/README.md
+++ b/semver-parsers/README.md
@@ -35,7 +35,7 @@ import busymachines.semver._
 import busymachines.semver.syntax._
 
 val version        = SemanticVersion(1,0,0, Labels.rc(4))
-val stringRep      = version.lowercase // "1.0.0-rc4"
+val stringRepr     = version.lowercase // "1.0.0-rc4"
 val parsedVersion  = SemanticVersion.unsafeFromString(stringRepr)
 // version == parsedVersion
 ```

--- a/semver-parsers/README.md
+++ b/semver-parsers/README.md
@@ -1,0 +1,41 @@
+# busymachines-commons-semver-parsers
+
+[![Maven Central](https://img.shields.io/maven-central/v/com.busymachines/busymachines-commons-semver-parsers_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.busymachines/busymachines-commons-semver-parsers_2.12)
+
+## artifacts
+
+This module is vanilla scala _*only*_, cross-compiled against versions: `2.12.4`.
+
+The full module id is:
+`"com.busymachines" %% "busymachines-commons-semver-parsers" % "0.2.0-RC5"`
+
+### Transitive dependencies
+
+* [`core`](../core/README.md)
+* `atto` — parsing library
+ * `cats`
+
+## Description
+
+A companion to the [`semver`](../semver/README.md) module that provides a way to parse plain strings into the semantically meaningful `SemanticVersion` datatype.
+
+## Usage
+
+You are always guaranteed to be able to parse the string representations yielded by the helper methods in the `SemanticVersion` class.
+
+You have four methods found in `SemanticVersionParsers`:
+* `busymachines.semver.SemanticVersionParsers.parseSemanticVersion`
+* `busymachines.semver.SemanticVersionParsers.parseLabel`
+* `busymachines.semver.SemanticVersionParsers.unsafeParseSemanticVersion`
+* `busymachines.semver.SemanticVersionParsers.unsafeParseSemanticVersion`
+
+And their counterpart syntactic sugars enabled by importing the `import busymachines.semver.syntax._`
+```scala
+import busymachines.semver._
+import busymachines.semver.syntax._
+
+val version        = SemanticVersion(1,0,0, Labels.rc(4))
+val stringRep      = version.lowercase // "1.0.0-rc4"
+val parsedVersion  = SemanticVersion.unsafeFromString(stringRepr)
+// version == parsedVersion
+```

--- a/semver-parsers/src/main/scala/busymachines/semver/SemanticVersionParsers.scala
+++ b/semver-parsers/src/main/scala/busymachines/semver/SemanticVersionParsers.scala
@@ -1,0 +1,168 @@
+package busymachines.semver
+
+/**
+  *
+  * A fairly straight-forward definition of parsers.
+  *
+  * It supports parsing all values outputed by the pretty printing helper methods:
+  * [[SemanticVersion.uppercase]], [[SemanticVersion.uppercaseWithDots]],
+  * [[SemanticVersion.lowercase]], [[SemanticVersion.lowercaseWithDots]]
+  *
+  * @author Lorand Szakacs, lsz@lorandszakacs.com, lorand.szakacs@busymachines.com
+  * @since 13 Nov 2017
+  *
+  */
+object SemanticVersionParsers {
+
+  type SemVerParsingResult[T] = Either[InvalidSemanticVersionParsingFailure, T]
+
+  import atto._
+  import atto.parser.all._
+  import atto.syntax.all._
+
+  def parseSemanticVersion(semver: String): SemVerParsingResult[SemanticVersion] = {
+    Parser.parseOnly(semanticVersionEOI, semver).either.left.map { parseError =>
+      InvalidSemanticVersionFailure(semver, parseError)
+    }
+  }
+
+  def unsafeParseSemanticVersion(semVer: String): SemanticVersion = {
+    parseSemanticVersion(semVer).toTry.get
+  }
+
+  def parseLabel(label: String): SemVerParsingResult[Label] = {
+    Parser.parseOnly(labelParserEOI, label).either.left.map { parseError =>
+      InvalidSemanticVersionLabelFailure(label, parseError)
+    }
+  }
+
+  def unsafeParseLabel(label: String): Label = {
+    this.parseLabel(label).toTry.get
+  }
+
+  private val dotParser: Parser[Char] = char('.')
+  private val dashParser: Parser[Char] = char('-')
+  private val plusParser: Parser[Char] = char('+')
+
+  private val SNAPSHOT: String = "SNAPSHOT"
+  private val ALPHA: String = "ALPHA"
+  private val BETA: String = "BETA"
+  private val M: String = "M"
+  private val RC: String = "RC"
+
+  private val snapshotParser: Parser[Label] = stringCI(SNAPSHOT).map(_ => Labels.snapshot)
+
+  private val alphaParser: Parser[Label] = {
+    val singleton: Parser[Label] = for {
+      _ <- stringCI(ALPHA)
+    } yield Labels.alpha
+
+    val completeWithDot: Parser[Label] = for {
+      _ <- singleton
+      _ <- dotParser
+      a <- int
+    } yield Labels.alpha(a)
+
+    val completeNoDot: Parser[Label] = for {
+      _ <- singleton
+      a <- int
+    } yield Labels.alpha(a)
+
+    completeWithDot | completeNoDot | singleton
+  }
+
+  private val betaParser: Parser[Label] = {
+    val singleton: Parser[Label] = for {
+      _ <- stringCI(BETA)
+    } yield Labels.beta
+
+    val completeWithDot: Parser[Label] = for {
+      _ <- singleton
+      _ <- dotParser
+      b <- int
+    } yield Labels.beta(b)
+
+    val completeNoDot: Parser[Label] = for {
+      _ <- singleton
+      b <- int
+    } yield Labels.beta(b)
+
+    completeWithDot | completeNoDot | singleton
+  }
+
+  private val milestoneParser: Parser[Label] = {
+    val singleton: Parser[String] = stringCI(M)
+
+    val completeWithDot: Parser[Label] = for {
+      _ <- singleton
+      _ <- dotParser
+      m <- int
+    } yield Labels.m(m)
+
+    val completeNoDot: Parser[Label] = for {
+      _ <- singleton
+      m <- int
+    } yield Labels.m(m)
+
+    completeWithDot | completeNoDot
+  }
+
+  private val releaseCandidateParser: Parser[Label] = {
+    val singleton: Parser[String] = stringCI(RC)
+
+    val completeWithDot: Parser[Label] = for {
+      _ <- singleton
+      _ <- dotParser
+      rc <- int
+    } yield Labels.rc(rc)
+
+    val completeNoDot: Parser[Label] = for {
+      _ <- singleton
+      rc <- int
+    } yield Labels.rc(rc)
+
+    completeWithDot | completeNoDot
+  }
+
+  private val labelParser: Parser[Label] = {
+    snapshotParser | alphaParser | betaParser | milestoneParser | releaseCandidateParser
+  }
+
+  private val labelParserEOI: Parser[Label] =
+    labelParser <~ endOfInput
+
+  private val metaParser: Parser[String] = takeText
+
+  private val semanticVersionParser: Parser[SemanticVersion] = {
+    val dashWithLabel = for {
+      _ <- dashParser
+      label <- labelParser
+    } yield label
+
+    val plusWithMeta = for {
+      _ <- plusParser
+      meta <- metaParser
+    } yield meta
+
+    for {
+      major <- int
+      _ <- dotParser
+      minor <- int
+      _ <- dotParser
+      patch <- int
+      optLabel <- opt(dashWithLabel)
+      optMeta <- opt(plusWithMeta)
+    } yield
+      SemanticVersion(
+        major = major,
+        minor = minor,
+        patch = patch,
+        label = optLabel,
+        meta = optMeta
+      )
+  }
+
+  private val semanticVersionEOI: Parser[SemanticVersion] =
+    semanticVersionParser <~ endOfInput
+
+}

--- a/semver-parsers/src/main/scala/busymachines/semver/semVerParsingFailures.scala
+++ b/semver-parsers/src/main/scala/busymachines/semver/semVerParsingFailures.scala
@@ -1,0 +1,46 @@
+package busymachines.semver
+
+import busymachines.core.exceptions.FailureMessage.Parameters
+import busymachines.core.exceptions._
+
+/**
+  *
+  * @author Lorand Szakacs, lsz@lorandszakacs.com, lorand.szakacs@busymachines.com
+  * @since 13 Nov 2017
+  *
+  */
+sealed abstract class InvalidSemanticVersionParsingFailure(m: String) extends InvalidInputFailure(m)
+
+final case class InvalidSemanticVersionFailure(input: String, parseError: String) extends InvalidSemanticVersionParsingFailure(
+  s"Failed to parse semantic version '$input' because: $parseError"
+) {
+  override def id: FailureID = ParsingFailureIDs.InvalidSemanticVersion
+
+  override val parameters: Parameters = Parameters(
+    "input" -> input,
+    "parseError" -> parseError
+  )
+}
+
+final case class InvalidSemanticVersionLabelFailure(input: String, parseError: String) extends InvalidSemanticVersionParsingFailure(
+  s"Failed to parse label of semantic version '$input' because: $parseError"
+) {
+  override def id: FailureID = ParsingFailureIDs.InvalidSemanticVersionLabel
+
+  override val parameters: Parameters = Parameters(
+    "input" -> input,
+    "parseError" -> parseError
+  )
+}
+
+object ParsingFailureIDs {
+
+  case object InvalidSemanticVersion extends FailureID {
+    override def name: String = "BMC_P_1"
+  }
+
+  case object InvalidSemanticVersionLabel extends FailureID {
+    override def name: String = "BMC_P_2"
+  }
+
+}

--- a/semver-parsers/src/main/scala/busymachines/semver/syntax.scala
+++ b/semver-parsers/src/main/scala/busymachines/semver/syntax.scala
@@ -1,0 +1,29 @@
+package busymachines.semver
+
+import busymachines.semver.SemanticVersionParsers.SemVerParsingResult
+
+/**
+  *
+  * @author Lorand Szakacs, lsz@lorandszakacs.com, lorand.szakacs@busymachines.com
+  * @since 13 Nov 2017
+  *
+  */
+object syntax {
+
+  implicit class SemanticVersionCompanionOps(doNotCare: SemanticVersion.type) {
+    def fromString(semVer: String): SemVerParsingResult[SemanticVersion] =
+      SemanticVersionParsers.parseSemanticVersion(semVer)
+
+    def unsafeFromString(semVer: String): SemanticVersion =
+      SemanticVersionParsers.unsafeParseSemanticVersion(semVer)
+  }
+
+  implicit class SemanticVersionLabelCompanionOps(doNotCare: Labels.type) {
+    def fromString(semVer: String): SemVerParsingResult[Label] =
+      SemanticVersionParsers.parseLabel(semVer)
+
+    def unsafeFromString(label: String): Label =
+      SemanticVersionParsers.unsafeParseLabel(label)
+  }
+
+}

--- a/semver-parsers/src/test/scala/busymachines/semver/SemanticVersionGenerators.scala
+++ b/semver-parsers/src/test/scala/busymachines/semver/SemanticVersionGenerators.scala
@@ -1,0 +1,51 @@
+package busymachines.semver
+
+import org.scalacheck.Gen
+
+/**
+  *
+  * @author Lorand Szakacs, lsz@lorandszakacs.com, lorand.szakacs@busymachines.com
+  * @since 13 Nov 2017
+  *
+  */
+trait SemanticVersionGenerators {
+
+  private val snapshotLabelGen: Gen[Label] = Gen.const(Labels.snapshot)
+  private val alphaSingletonGen: Gen[Label] = Gen.const(Labels.alpha)
+  private val alphaGen: Gen[Label] = Gen.posNum[Int].map(i => Labels.alpha(i))
+  private val betaSingletonGen: Gen[Label] = Gen.const(Labels.beta)
+  private val betaGen: Gen[Label] = Gen.posNum[Int].map(i => Labels.beta(i))
+  private val rcGen: Gen[Label] = Gen.posNum[Int].map(i => Labels.rc(i))
+  private val mGen: Gen[Label] = Gen.posNum[Int].map(i => Labels.m(i))
+
+  implicit val labelGenerator: Gen[Label] = {
+    Gen.oneOf(
+      snapshotLabelGen,
+      alphaSingletonGen,
+      alphaGen,
+      betaSingletonGen,
+      betaGen,
+      rcGen,
+      mGen
+    )
+  }
+
+  implicit val semanticVersionGenerator: Gen[SemanticVersion] = {
+    for {
+      major <- Gen.posNum[Int]
+      minor <- Gen.posNum[Int]
+      patch <- Gen.posNum[Int]
+      optLabel <- Gen.option(labelGenerator)
+      optMeta <- Gen.option(Gen.alphaStr)
+    } yield SemanticVersion(
+      major = major,
+      minor = minor,
+      patch = patch,
+      label = optLabel,
+      meta = optMeta
+    )
+
+  }
+
+
+}

--- a/semver-parsers/src/test/scala/busymachines/semver/SemanticVersionParserTest.scala
+++ b/semver-parsers/src/test/scala/busymachines/semver/SemanticVersionParserTest.scala
@@ -1,0 +1,185 @@
+package busymachines.semver
+
+import org.scalatest.{FlatSpec, Matchers}
+
+/**
+  *
+  * @author Lorand Szakacs, lsz@lorandszakacs.com, lorand.szakacs@busymachines.com
+  * @since 13 Nov 2017
+  *
+  */
+class SemanticVersionParserTest extends FlatSpec with Matchers {
+
+  behavior of "SemanticVersion parsers"
+
+  it should "parse: 1.20.345" in {
+    val input = "1.20.345"
+    assert(parse(input) == SemanticVersion(1, 20, 345))
+  }
+
+  it should "parse: 1.20.345-snapshot" in {
+    val input = "1.20.345-snapshot"
+    assert(parse(input) == SemanticVersion(1, 20, 345, Labels.snapshot))
+  }
+
+  it should "parse: 1.20.345-SNAPSHOT" in {
+    val input = "1.20.345-SNAPSHOT"
+    assert(parse(input) == SemanticVersion(1, 20, 345, Labels.snapshot))
+  }
+
+  //===========================================================================
+
+  it should "parse: 1.20.345-alpha" in {
+    val input = "1.20.345-alpha"
+    assert(parse(input) == SemanticVersion(1, 20, 345, Labels.alpha))
+  }
+
+  it should "parse: 1.20.345-ALPHA" in {
+    val input = "1.20.345-ALPHA"
+    assert(parse(input) == SemanticVersion(1, 20, 345, Labels.alpha))
+  }
+
+  it should "parse: 1.20.345-alpha.1" in {
+    val input = "1.20.345-alpha.1"
+    assert(parse(input) == SemanticVersion(1, 20, 345, Labels.alpha(1)))
+  }
+
+  it should "parse: 1.20.345-ALPHA.2" in {
+    val input = "1.20.345-ALPHA.2"
+    assert(parse(input) == SemanticVersion(1, 20, 345, Labels.alpha(2)))
+  }
+
+  it should "parse: 1.20.345-alpha3" in {
+    val input = "1.20.345-alpha3"
+    assert(parse(input) == SemanticVersion(1, 20, 345, Labels.alpha(3)))
+  }
+
+  it should "parse: 1.20.345-ALPHA4" in {
+    val input = "1.20.345-ALPHA4"
+    assert(parse(input) == SemanticVersion(1, 20, 345, Labels.alpha(4)))
+  }
+
+  //===========================================================================
+
+  it should "parse: 1.20.345-beta" in {
+    val input = "1.20.345-beta"
+    assert(parse(input) == SemanticVersion(1, 20, 345, Labels.beta))
+  }
+
+  it should "parse: 1.20.345-BETA" in {
+    val input = "1.20.345-BETA"
+    assert(parse(input) == SemanticVersion(1, 20, 345, Labels.beta))
+  }
+
+  it should "parse: 1.20.345-beta.1" in {
+    val input = "1.20.345-beta.1"
+    assert(parse(input) == SemanticVersion(1, 20, 345, Labels.beta(1)))
+  }
+
+  it should "parse: 1.20.345-BETA.2" in {
+    val input = "1.20.345-BETA.2"
+    assert(parse(input) == SemanticVersion(1, 20, 345, Labels.beta(2)))
+  }
+
+  it should "parse: 1.20.345-beta3" in {
+    val input = "1.20.345-beta3"
+    assert(parse(input) == SemanticVersion(1, 20, 345, Labels.beta(3)))
+  }
+
+  it should "parse: 1.20.345-BETA4" in {
+    val input = "1.20.345-BETA4"
+    assert(parse(input) == SemanticVersion(1, 20, 345, Labels.beta(4)))
+  }
+
+  //===========================================================================
+
+  it should "parse: 1.20.345-m.1" in {
+    val input = "1.20.345-m.1"
+    assert(parse(input) == SemanticVersion(1, 20, 345, Labels.m(1)))
+  }
+
+  it should "parse: 1.20.345-M.2" in {
+    val input = "1.20.345-M.2"
+    assert(parse(input) == SemanticVersion(1, 20, 345, Labels.m(2)))
+  }
+
+  it should "parse: 1.20.345-m3" in {
+    val input = "1.20.345-m3"
+    assert(parse(input) == SemanticVersion(1, 20, 345, Labels.m(3)))
+  }
+
+  it should "parse: 1.20.345-M4" in {
+    val input = "1.20.345-M4"
+    assert(parse(input) == SemanticVersion(1, 20, 345, Labels.m(4)))
+  }
+
+  //===========================================================================
+
+  it should "parse: 1.20.345-rc.1" in {
+    val input = "1.20.345-rc.1"
+    assert(parse(input) == SemanticVersion(1, 20, 345, Labels.rc(1)))
+  }
+
+  it should "parse: 1.20.345-RC.2" in {
+    val input = "1.20.345-RC.2"
+    assert(parse(input) == SemanticVersion(1, 20, 345, Labels.rc(2)))
+  }
+
+  it should "parse: 1.20.345-rc3" in {
+    val input = "1.20.345-rc3"
+    assert(parse(input) == SemanticVersion(1, 20, 345, Labels.rc(3)))
+  }
+
+  it should "parse: 1.20.345-RC4" in {
+    val input = "1.20.345-RC4"
+    assert(parse(input) == SemanticVersion(1, 20, 345, Labels.rc(4)))
+  }
+
+  //===========================================================================
+
+  it should "parse: 1.20.345-snapshot+1234124" in {
+    val input = "1.20.345-snapshot+1234124"
+    assert(parse(input) == SemanticVersion(1, 20, 345, Labels.snapshot, Option("1234124")))
+  }
+
+  it should "parse: 1.20.345-SNAPSHOT+1234124" in {
+    val input = "1.20.345-SNAPSHOT+1234124"
+    assert(parse(input) == SemanticVersion(1, 20, 345, Labels.snapshot, Option("1234124")))
+  }
+
+  it should "parse: 1.20.345+1234124" in {
+    val input = "1.20.345+1234124"
+    assert(parse(input) == SemanticVersion(1, 20, 345, None, Option("1234124")))
+  }
+
+  //FIXME: is this correct???
+  it should "parse: 1.20.345+ — empty meta as empty string" in {
+    val input = "1.20.345+"
+    assert(parse(input) == SemanticVersion(1, 20, 345, None, Option("")))
+  }
+
+  //FIXME: is this correct???
+  it should "parse: 1.20.345+asfsd sfddsf — meta with spaces" in {
+    val input = "1.20.345+asfsd sfddsf"
+    assert(parse(input) == SemanticVersion(1, 20, 345, None, Option("asfsd sfddsf")))
+  }
+
+  //===========================================================================
+
+  it should "parse: 1.20.345 — fail on invalid input" in {
+    val input = "1.20.345asdf"
+    failOn(input)
+  }
+
+  //===========================================================================
+
+  def parse(i: String): SemanticVersion = {
+    SemanticVersionParsers.unsafeParseSemanticVersion(i)
+  }
+
+  def failOn(i: String): InvalidSemanticVersionFailure = {
+    the[InvalidSemanticVersionFailure] thrownBy {
+      SemanticVersionParsers.unsafeParseSemanticVersion(i)
+    }
+  }
+}

--- a/semver-parsers/src/test/scala/busymachines/semver/SemanticVersionToStringFromStringPropertyCheck.scala
+++ b/semver-parsers/src/test/scala/busymachines/semver/SemanticVersionToStringFromStringPropertyCheck.scala
@@ -1,0 +1,74 @@
+package busymachines.semver
+
+import org.scalatest._
+import org.scalatest.prop.PropertyChecks
+
+/**
+  *
+  * @author Lorand Szakacs, lsz@lorandszakacs.com, lorand.szakacs@busymachines.com
+  * @since 13 Nov 2017
+  *
+  */
+class SemanticVersionToStringFromStringPropertyCheck extends FunSpec with PropertyChecks with SemanticVersionGenerators {
+
+  describe("Label parser") {
+    it("should be able to parse all lowercase representations of Label") {
+      forAll(labelGenerator) { original: Label =>
+        val parsed = SemanticVersionParsers.unsafeParseLabel(original.lowercase)
+        assert(parsed == original)
+      }
+    }
+
+    it("should be able to parse all lowercaseWithDot representations of Label") {
+      forAll(labelGenerator) { original: Label =>
+        val parsed = SemanticVersionParsers.unsafeParseLabel(original.lowercaseWithDots)
+        assert(parsed == original)
+      }
+    }
+
+    it("should be able to parse all uppercase representations of Label") {
+      forAll(labelGenerator) { original: Label =>
+        val parsed = SemanticVersionParsers.unsafeParseLabel(original.uppercase)
+        assert(parsed == original)
+      }
+    }
+
+    it("should be able to parse all uppercaseWithDot representations of Label") {
+      forAll(labelGenerator) { original: Label =>
+        val parsed = SemanticVersionParsers.unsafeParseLabel(original.uppercaseWithDots)
+        assert(parsed == original)
+      }
+    }
+  }
+
+  describe("SemanticVersion parser") {
+    it("should be able to parse all lowercase representations of SemVer") {
+      forAll(semanticVersionGenerator) { original: SemanticVersion =>
+        val parsed = SemanticVersionParsers.unsafeParseSemanticVersion(original.lowercase)
+        assert(parsed == original)
+      }
+    }
+
+    it("should be able to parse all lowercaseWithDots representations of SemVer") {
+      forAll(semanticVersionGenerator) { original: SemanticVersion =>
+        val parsed = SemanticVersionParsers.unsafeParseSemanticVersion(original.lowercaseWithDots)
+        assert(parsed == original)
+      }
+    }
+
+    it("should be able to parse all uppercase representations of SemVer") {
+      forAll(semanticVersionGenerator) { original: SemanticVersion =>
+        val parsed = SemanticVersionParsers.unsafeParseSemanticVersion(original.uppercase)
+        assert(parsed == original)
+      }
+    }
+
+    it("should be able to parse all uppercaseWithDots representations of SemVer") {
+      forAll(semanticVersionGenerator) { original: SemanticVersion =>
+        val parsed = SemanticVersionParsers.unsafeParseSemanticVersion(original.uppercaseWithDots)
+        assert(parsed == original)
+      }
+    }
+  }
+
+}

--- a/semver/README.md
+++ b/semver/README.md
@@ -4,10 +4,10 @@
 
 ## artifacts
 
-This module is vanilla scala _*only*_, cross-compiled against versions: `2.12.4`.
+This module is vanilla scala _*only*_, cross-compiled against versions: `2.12.3`.
 
 The full module id is:
-`"com.busymachines" %% "busymachines-commons-semver" % "0.2.0-RC5"`
+`"com.busymachines" %% "busymachines-commons-semver" % "0.2.0-RC6"`
 
 ### Transitive dependencies
 None.

--- a/semver/README.md
+++ b/semver/README.md
@@ -1,0 +1,105 @@
+# busymachines-commons-semver
+
+[![Maven Central](https://img.shields.io/maven-central/v/com.busymachines/busymachines-commons-semver_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.busymachines/busymachines-commons-semver_2.12)
+
+## artifacts
+
+This module is vanilla scala _*only*_, cross-compiled against versions: `2.12.4`.
+
+The full module id is:
+`"com.busymachines" %% "busymachines-commons-semver" % "0.2.0-RC5"`
+
+### Transitive dependencies
+None.
+
+## Description
+
+A simple library containing one type, `SemanticVersion` with a defined natural ordering as defined by the [semantic versioning specification 2.0.0](http://semver.org/spec/v2.0.0.html#spec-item-11).
+
+Currently, the type does not support arbitrary naming of your pre-release labels, but rather constrains you to 4 types: `alpha` < `beta` < `M` (milestone) < `RC` (Release Candidate). In future version an arbitrary label will be added.
+
+## String representations
+
+If you want to parse plain strings into the `SemanticVersion` type, then use the [`semver-parsers`](../semver-parsers/README.md) module. All stringy representations of `SemanticVersion.lowercase/uppercase/etc...` are parseable by that module.
+
+The case class `SemanticVersion` has 4 string representations that are seen in the "wild" — more or less. Any descriptors apply strictly to the representation of the `label`. The results are equivalent if you only have a semantic version with the non-optional fields: `major`, `minor`, `patch`.
+
+## Ordering
+The library is in accordance with the [semantic version specification](http://semver.org/spec/v2.0.0.html#spec-item-11):
+```
+SemanticVersion(1, 0, 0)                   >
+ SemanticVersion(1, 0, 0, Labels.rc(2))     >
+  SemanticVersion(1, 0, 0, Labels.rc(1))     >
+   SemanticVersion(1, 0, 0, Labels.m(1))      >
+    SemanticVersion(1, 0, 0, Labels.beta(1))   >
+     SemanticVersion(1, 0, 0, Labels.beta)      >
+      SemanticVersion(1, 0, 0, Labels.alpha(1))  >
+       SemanticVersion(1, 0, 0, Labels.alpha)     >
+        SemanticVersion(1, 0, 0, Labels.snapshot)
+```
+
+## Examples of string representations
+
+```scala
+import busymachines.semver._
+val version = SemanticVersion(1, 0, 0)
+// version.lowercase == "1.0.0"
+// version.uppercase == "1.0.0"
+// version.lowercaseWithDots == "1.0.0"
+// version.uppercaseWithDots == "1.0.0"
+
+
+val snapshot = SemanticVersion(1, 0, 0, Labels.snapshot)
+// snapshot.lowercase == "1.0.0-snapshot"
+// snapshot.uppercase == "1.0.0-SNAPSHOT"
+// snapshot.lowercaseWithDots == "1.0.0-snapshot
+// snapshot.uppercaseWithDots == "1.0.0-snapshot
+
+
+val alphaSingle = SemanticVersion(1, 0, 0, Labels.alpha)
+// alphaSingle.lowercase == "1.0.0-alpha"
+// alphaSingle.uppercase == "1.0.0-ALPHA"
+// alphaSingle.lowercaseWithDots == "1.0.0-alpha"
+// alphaSingle.uppercaseWithDots == "1.0.0-ALPHA"
+
+val alpha1 = SemanticVersion(1, 0, 0, Labels.alpha(1))
+// alpha1.lowercase == "1.0.0-alpha1"
+// alpha1.uppercase == "1.0.0-ALPHA1"
+// alpha1.lowercaseWithDots == "1.0.0-alpha.1"
+// alpha1.uppercaseWithDots == "1.0.0-ALPHA.1"
+
+
+val betaSingle = SemanticVersion(1, 0, 0, Labels.beta)
+// betaSingle.lowercase == "1.0.0-beta"
+// betaSingle.uppercase == "1.0.0-BETA"
+// betaSingle.lowercaseWithDots == "1.0.0-beta"
+// betaSingle.uppercaseWithDots == "1.0.0-BETA"
+
+
+val beta1 = SemanticVersion(1, 0, 0, Labels.beta(1))
+// betaSingle.lowercase == "1.0.0-beta"
+// betaSingle.uppercase == "1.0.0-BETA"
+// betaSingle.lowercaseWithDots == "1.0.0-beta"
+// betaSingle.uppercaseWithDots == "1.0.0-BETA"
+
+
+val m1 = SemanticVersion(1, 0, 0, Labels.m(1))
+// m1.lowercase == "1.0.0-m1"
+// m1.uppercase == "1.0.0-M1"
+// m1.lowercaseWithDots == "1.0.0-m.1"
+// m1.uppercaseWithDots == "1.0.0-M.1"
+
+
+val rc1 = SemanticVersion(1, 0, 0, Labels.rc(1))
+// rc1.lowercase == "1.0.0-rc1"
+// rc1.uppercase == "1.0.0-RC1"
+// rc1.lowercaseWithDots == "1.0.0-rc.1"
+// rc1.uppercaseWithDots == "1.0.0-RC.1"
+
+val rc1WMeta = SemanticVersion(1, 0, 0, Labels.rc(1), Option("7777"))
+// rc1WMeta.lowercase == "1.0.0-rc1+7777"
+// rc1WMeta.uppercase == "1.0.0-RC1+7777"
+// rc1WMeta.lowercaseWithDots == "1.0.0-rc.1+7777"
+// rc1WMeta.uppercaseWithDots == "1.0.0-RC.1+7777"
+
+```

--- a/semver/src/main/scala/busymachines/semver/SemanticVersionShows.scala
+++ b/semver/src/main/scala/busymachines/semver/SemanticVersionShows.scala
@@ -1,0 +1,95 @@
+package busymachines.semver
+
+import busymachines.semver.Labels._
+
+/**
+  * Since there are multiple string representations of [[SemanticVersion]] in the wild,
+  * we provide several out of the box, depending on the two variables:
+  *  - lowercase/uppercase labels
+  *  - RC.1 vs RC1 — and so on, dot separated labels, or no separation
+  *
+  * @author Lorand Szakacs, lsz@lorandszakacs.com, lorand.szakacs@busymachines.com
+  * @since 13 Nov 2017
+  *
+  */
+private[semver] object SemanticVersionShows {
+
+  private val EmptyString = ""
+  private val Dot = "."
+
+  object lowercase {
+    private val snapshot: String = "snapshot"
+    private val alpha: String = "alpha"
+    private val beta: String = "beta"
+    private val m: String = "m"
+    private val rc: String = "rc"
+
+    object withDotSeparator {
+      def show(sv: SemanticVersion): String = genericSVLowercaseShow(sv, Dot)
+
+      def show(l: Label): String = genericLowercaseLabelShow(l, Dot)
+    }
+
+    object noSeparator {
+      def show(sv: SemanticVersion): String = genericSVLowercaseShow(sv, EmptyString)
+
+      def show(l: Label): String = genericLowercaseLabelShow(l, EmptyString)
+    }
+
+    private[lowercase] def genericSVLowercaseShow(sv: SemanticVersion, separator: String): String = {
+      val majorMinorPatch = s"${sv.major}.${sv.minor}.${sv.patch}"
+      val preReleaseLabel = if (sv.label.isEmpty) EmptyString else s"-${genericLowercaseLabelShow(sv.label.get, separator)}"
+      val metaLabel = if (sv.meta.isEmpty) EmptyString else s"+${sv.meta.get.trim}"
+      s"$majorMinorPatch$preReleaseLabel$metaLabel"
+    }
+
+    private[lowercase] def genericLowercaseLabelShow(l: Label, separator: String): String = l match {
+      case Snapshot => snapshot
+      case AlphaSingleton => alpha
+      case Alpha(alphaVer) => s"$alpha$separator$alphaVer"
+      case BetaSingleton => beta
+      case Beta(betaVer) => s"$beta$separator$betaVer"
+      case Milestone(mVer) => s"$m$separator$mVer"
+      case ReleaseCandidate(rcVer) => s"$rc$separator$rcVer"
+    }
+  }
+
+  object uppercase {
+    private val SNAPSHOT: String = "SNAPSHOT"
+    private val ALPHA: String = "ALPHA"
+    private val BETA: String = "BETA"
+    private val M: String = "M"
+    private val RC: String = "RC"
+
+
+    object withDotSeparator {
+      def show(sv: SemanticVersion): String = genericSVUppercaseShow(sv, Dot)
+
+      def show(l: Label): String = genericUppercaseLabelShow(l, Dot)
+    }
+
+    object noSeparator {
+      def show(sv: SemanticVersion): String = genericSVUppercaseShow(sv, EmptyString)
+
+      def show(l: Label): String = genericUppercaseLabelShow(l, EmptyString)
+    }
+
+    private[uppercase] def genericSVUppercaseShow(sv: SemanticVersion, separator: String): String = {
+      val majorMinorPatch = s"${sv.major}.${sv.minor}.${sv.patch}"
+      val preReleaseLabel = if (sv.label.isEmpty) EmptyString else s"-${genericUppercaseLabelShow(sv.label.get, separator)}"
+      val metaLabel = if (sv.meta.isEmpty) EmptyString else s"+${sv.meta.get.trim}"
+      s"$majorMinorPatch$preReleaseLabel$metaLabel"
+    }
+
+    private[uppercase] def genericUppercaseLabelShow(l: Label, separator: String): String = l match {
+      case Snapshot => SNAPSHOT
+      case AlphaSingleton => ALPHA
+      case Alpha(alphaVer) => s"$ALPHA$separator$alphaVer"
+      case BetaSingleton => BETA
+      case Beta(betaVer) => s"$BETA$separator$betaVer"
+      case Milestone(mVer) => s"$M$separator$mVer"
+      case ReleaseCandidate(rcVer) => s"$RC$separator$rcVer"
+    }
+  }
+
+}

--- a/semver/src/main/scala/busymachines/semver/orderings.scala
+++ b/semver/src/main/scala/busymachines/semver/orderings.scala
@@ -1,0 +1,185 @@
+package busymachines.semver
+
+import busymachines.semver.Labels._
+
+/**
+  *
+  * @author Lorand Szakacs, lsz@lorandszakacs.com, lorand.szakacs@busymachines.com
+  * @since 13 Nov 2017
+  *
+  */
+private[semver] trait LabelOrdering extends Ordered[Label]
+
+/**
+  * -SNAPSHOT label is always "less than" any other label,
+  * and since they are not numbered, it's "equal" to any other
+  * label
+  */
+private[semver] trait SnapshotOrdering extends Ordered[Label] {
+  this: Labels.Snapshot.type =>
+
+  import OrderingUtils._
+
+
+  override def compare(that: Label): Int = that match {
+    case Snapshot => EQ
+    case AlphaSingleton => LT
+    case _: Alpha => LT
+    case BetaSingleton => LT
+    case _: Beta => LT
+    case _: Milestone => LT
+    case _: ReleaseCandidate => LT
+  }
+}
+
+private[semver] trait AlphaSingletonOrdering extends Ordered[Label] {
+  this: Labels.AlphaSingleton.type =>
+
+  import OrderingUtils._
+
+  override def compare(that: Label): Int = that match {
+    case Snapshot => GT
+    case AlphaSingleton => EQ
+    case _: Alpha => LT
+    case BetaSingleton => LT
+    case _: Beta => LT
+    case _: Milestone => LT
+    case _: ReleaseCandidate => LT
+  }
+}
+
+private[semver] trait AlphaOrdering extends Ordered[Label] {
+  this: Labels.Alpha =>
+
+  import OrderingUtils._
+
+  override def compare(that: Label): Int = that match {
+    case Snapshot => GT
+    case AlphaSingleton => GT
+    case Alpha(thatAlpha) => this.alpha.compareTo(thatAlpha)
+    case BetaSingleton => LT
+    case _: Beta => LT
+    case _: Milestone => LT
+    case _: ReleaseCandidate => LT
+  }
+}
+
+private[semver] trait BetaSingletonOrdering extends Ordered[Label] {
+  this: Labels.BetaSingleton.type =>
+
+  import OrderingUtils._
+
+  override def compare(that: Label): Int = that match {
+    case Snapshot => GT
+    case AlphaSingleton => GT
+    case _: Alpha => GT
+    case BetaSingleton => EQ
+    case _: Beta => LT
+    case _: Milestone => LT
+    case _: ReleaseCandidate => LT
+  }
+}
+
+private[semver] trait BetaOrdering extends Ordered[Label] {
+  this: Labels.Beta =>
+
+  import OrderingUtils._
+
+  override def compare(that: Label): Int = that match {
+    case Snapshot => GT
+    case AlphaSingleton => GT
+    case _: Alpha => GT
+    case BetaSingleton => GT
+    case Beta(thatBeta) => this.beta.compareTo(thatBeta)
+    case _: Milestone => LT
+    case _: ReleaseCandidate => LT
+  }
+}
+
+private[semver] trait MilestoneOrdering extends Ordered[Label] {
+  this: Labels.Milestone =>
+
+  import OrderingUtils._
+
+  override def compare(that: Label): Int = that match {
+    case Snapshot => GT
+    case AlphaSingleton => GT
+    case _: Alpha => GT
+    case BetaSingleton => GT
+    case _: Beta => GT
+    case Milestone(thatM) => this.m.compareTo(thatM)
+    case _: ReleaseCandidate => LT
+  }
+}
+
+private[semver] trait ReleaseCandidateOrdering extends Ordered[Label] {
+  this: Labels.ReleaseCandidate =>
+
+  import OrderingUtils._
+
+  override def compare(that: Label): Int = that match {
+    case Snapshot => GT
+    case AlphaSingleton => GT
+    case _: Alpha => GT
+    case BetaSingleton => GT
+    case _: Beta => GT
+    case _: Milestone => GT
+    case ReleaseCandidate(thatRC) => this.rc.compareTo(thatRC)
+  }
+}
+
+
+private[semver] trait SemanticVersionOrdering extends Ordered[SemanticVersion] {
+  this: SemanticVersion =>
+  /**
+    * See ordering rules:
+    * In the sem-ver spec:
+    * http://semver.org/spec/v2.0.0.html
+    *
+    * Example:
+    * 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0
+    */
+  override def compare(that: SemanticVersion): Int = {
+    import OrderingUtils._
+    if (this == that) {
+      EQ
+    } else {
+      val majorComp = this.major.compareTo(that.major)
+      val minorComp = this.minor.compareTo(that.minor)
+      val patchComp = this.patch.compareTo(that.patch)
+      val labelComp = (this.label, that.label) match {
+        case (None, None) => EQ
+        case (Some(_), None) => LT //basically 1.0.0-RC1 < 1.0.0, regardless of the value of the label
+        case (None, Some(_)) => GT //same thing as above
+        case (Some(thisLabel), Some(thatLabel)) =>
+          thisLabel.compareTo(thatLabel)
+      }
+
+      //this should be quite obvious, at each step in the hierarchy, if the numbers are equals
+      //then the result is given by the numbers further down in the hierarchy
+      if (majorComp == EQ) {
+        if (minorComp == EQ) {
+          if (patchComp == EQ) {
+            if (labelComp == EQ) {
+              EQ //technically already handled in that first comparison
+            } else {
+              labelComp
+            }
+          } else {
+            patchComp
+          }
+        } else {
+          minorComp
+        }
+      } else {
+        majorComp
+      }
+    }
+  }
+}
+
+private[semver] object OrderingUtils {
+  val GT: Int = 1
+  val LT: Int = -1
+  val EQ: Int = 0
+}

--- a/semver/src/main/scala/busymachines/semver/package.scala
+++ b/semver/src/main/scala/busymachines/semver/package.scala
@@ -1,0 +1,27 @@
+package busymachines
+
+import scala.language.implicitConversions
+
+/**
+  *
+  * @author Lorand Szakacs, lsz@lorandszakacs.com, lorand.szakacs@busymachines.com
+  * @since 13 Nov 2017
+  *
+  */
+package object semver {
+
+  /**
+    * convenient aliases to [[SemanticVersion]]. A lot of people use these names
+    * because of lazyness, might as well support some trivial type aliases
+    * out of the box.
+    */
+  type SemVer = SemanticVersion
+  val SemVer: SemanticVersion.type = SemanticVersion
+
+  /**
+    * In this particular case this is by no means a "dangerous" implicit,
+    * since we just want to do automatic lifting into Option, because
+    * it is the only way labels are used
+    */
+  implicit def labelToOptLabel(label: Label): Option[Label] = Option[Label](label)
+}

--- a/semver/src/main/scala/busymachines/semver/semanticVersion.scala
+++ b/semver/src/main/scala/busymachines/semver/semanticVersion.scala
@@ -10,7 +10,7 @@ package busymachines.semver
   * denotes various meta-information, that is included at the end of the version, after the "+" sign.
   * Examples: git sha version:
   * {{{
-  *      4.1.0-SNAPSHOT+11223aaff
+  *            4.1.0-SNAPSHOT+11223aaff
   * }}}
   * @author Lorand Szakacs, lsz@lorandszakacs.com, lorand.szakacs@busymachines.com
   * @since 10 Nov 2017
@@ -23,10 +23,76 @@ final case class SemanticVersion(
   label: Option[Label] = Option.empty[Label],
   meta: Option[String] = Option.empty[String]
 ) extends SemanticVersionOrdering with Ordered[SemanticVersion] {
-  override lazy val toString: String = s"$major.$minor.$patch" + label.map(l => s"-$l").getOrElse("") + meta.map(m => s"+$m")
+  /**
+    * eg:
+    * {{{
+    *   3.1.2-rc4+1234
+    * }}}
+    */
+  def lowercase: String = SemanticVersionShows.lowercase.noSeparator.show(this)
+
+  /**
+    * eg:
+    * {{{
+    *   3.1.2-rc.4+1234
+    * }}}
+    */
+  def lowercaseWithDots: String = SemanticVersionShows.lowercase.withDotSeparator.show(this)
+
+  /**
+    * eg:
+    * {{{
+    *   3.1.2-RC4+1234
+    * }}}
+    */
+  def uppercase: String = SemanticVersionShows.uppercase.noSeparator.show(this)
+
+  /**
+    * eg:
+    * {{{
+    *   3.1.2-RC.4+1234
+    * }}}
+    */
+  def uppercaseWithDots: String = SemanticVersionShows.uppercase.withDotSeparator.show(this)
+
+  override lazy val toString: String = uppercase
 }
 
-sealed trait Label extends Ordered[Label] with LabelOrdering
+sealed trait Label extends Ordered[Label] with LabelOrdering {
+  /**
+    * eg:
+    * {{{
+    *   rc4
+    * }}}
+    */
+  final def lowercase: String = SemanticVersionShows.lowercase.noSeparator.show(this)
+
+  /**
+    * eg:
+    * {{{
+    *   rc.4
+    * }}}
+    */
+  final def lowercaseWithDots: String = SemanticVersionShows.lowercase.withDotSeparator.show(this)
+
+  /**
+    * eg:
+    * {{{
+    *   RC4
+    * }}}
+    */
+  final def uppercase: String = SemanticVersionShows.uppercase.noSeparator.show(this)
+
+  /**
+    * eg:
+    * {{{
+    *   RC.4
+    * }}}
+    */
+  final def uppercaseWithDots: String = SemanticVersionShows.uppercase.withDotSeparator.show(this)
+
+  override def toString: String = uppercase
+}
 
 object Labels {
   def snapshot: Label = Snapshot
@@ -57,21 +123,4 @@ object Labels {
 
   private[semver] case class Milestone(m: Int) extends Label with MilestoneOrdering
 
-}
-
-private[semver] object SemanticVersion {
-  val Snapshot = "snapshot"
-  val SNAPSHOT = "SNAPSHOT"
-
-  val ReleaseCandidate = "rc"
-  val REALEASE_CANDIDATE = "RC"
-
-  val Milestone = "m"
-  val MILESTONE = "M"
-
-  val Alpha = "alpha"
-  val ALPHA = "ALPHA"
-
-  val Beta = "beta"
-  val BETA = "BETA"
 }

--- a/semver/src/main/scala/busymachines/semver/semanticVersion.scala
+++ b/semver/src/main/scala/busymachines/semver/semanticVersion.scala
@@ -1,0 +1,77 @@
+package busymachines.semver
+
+
+/**
+  *
+  * A type denoting semantic versions, eg:
+  * 4.1.0, with an optional label like "RC", or "beta", etc.
+  *
+  * @param meta
+  * denotes various meta-information, that is included at the end of the version, after the "+" sign.
+  * Examples: git sha version:
+  * {{{
+  *      4.1.0-SNAPSHOT+11223aaff
+  * }}}
+  * @author Lorand Szakacs, lsz@lorandszakacs.com, lorand.szakacs@busymachines.com
+  * @since 10 Nov 2017
+  *
+  */
+final case class SemanticVersion(
+  major: Int,
+  minor: Int,
+  patch: Int,
+  label: Option[Label] = Option.empty[Label],
+  meta: Option[String] = Option.empty[String]
+) extends SemanticVersionOrdering with Ordered[SemanticVersion] {
+  override lazy val toString: String = s"$major.$minor.$patch" + label.map(l => s"-$l").getOrElse("") + meta.map(m => s"+$m")
+}
+
+sealed trait Label extends Ordered[Label] with LabelOrdering
+
+object Labels {
+  def snapshot: Label = Snapshot
+
+  def alpha: Label = AlphaSingleton
+
+  def alpha(v: Int): Label = Alpha(v)
+
+  def beta: Label = BetaSingleton
+
+  def beta(v: Int): Label = Beta(v)
+
+  def rc(v: Int): Label = ReleaseCandidate(v)
+
+  def m(v: Int): Label = Milestone(v)
+
+  private[semver] case object Snapshot extends Label with SnapshotOrdering
+
+  private[semver] case object AlphaSingleton extends Label with AlphaSingletonOrdering
+
+  private[semver] case class Alpha(alpha: Int) extends Label with AlphaOrdering
+
+  private[semver] case object BetaSingleton extends Label with BetaSingletonOrdering
+
+  private[semver] case class Beta(beta: Int) extends Label with BetaOrdering
+
+  private[semver] case class ReleaseCandidate(rc: Int) extends Label with ReleaseCandidateOrdering
+
+  private[semver] case class Milestone(m: Int) extends Label with MilestoneOrdering
+
+}
+
+private[semver] object SemanticVersion {
+  val Snapshot = "snapshot"
+  val SNAPSHOT = "SNAPSHOT"
+
+  val ReleaseCandidate = "rc"
+  val REALEASE_CANDIDATE = "RC"
+
+  val Milestone = "m"
+  val MILESTONE = "M"
+
+  val Alpha = "alpha"
+  val ALPHA = "ALPHA"
+
+  val Beta = "beta"
+  val BETA = "BETA"
+}

--- a/semver/src/test/scala/busymachines/semver/SemanticVersionLabelOrderingTest.scala
+++ b/semver/src/test/scala/busymachines/semver/SemanticVersionLabelOrderingTest.scala
@@ -1,0 +1,290 @@
+package busymachines.semver
+
+import org.scalatest.{FlatSpec, Matchers}
+
+/**
+  *
+  * @author Lorand Szakacs, lsz@lorandszakacs.com, lorand.szakacs@busymachines.com
+  * @since 13 Nov 2017
+  *
+  */
+class SemanticVersionLabelOrderingTest extends FlatSpec with Matchers {
+
+  //technically I could have used >, ==, < operators as well
+  private implicit class LabelTestOps(label: Label) {
+    def assertGT(that: Label): Unit = {
+      assert(label.compareTo(that) > 0, s"$label should be greater than $that")
+    }
+
+    def assertEQ(that: Label): Unit = {
+      assert(label.compareTo(that) == 0, s"$label should be equal to $that")
+    }
+
+    def assertLT(that: Label): Unit = {
+      assert(label.compareTo(that) < 0, s"$label should be less than $that")
+    }
+  }
+
+  behavior of "semver label snapshot"
+
+  it should "be equal to snapshot label" in {
+    val l1 = Labels.snapshot
+    val l2 = Labels.snapshot
+
+    l1 assertEQ l2
+    l2 assertEQ l1
+  }
+
+
+  behavior of "semver label alpha"
+
+  it should "be the same as Int natural ordering when comparing with other alphas" in {
+    withClue("EQ") {
+      val l1 = Labels.alpha(1)
+      val l2 = Labels.alpha(1)
+
+      l1 assertEQ l2
+      l2 assertEQ l1
+    }
+
+    withClue("LT/GT") {
+      val l1 = Labels.alpha(1)
+      val l2 = Labels.alpha(2)
+
+      l1 assertLT l2
+      l2 assertGT l1
+    }
+  }
+
+  behavior of "semver label alpha-singleton"
+
+  it should "only equal alpha singleton < alpha" in {
+    withClue("EQ") {
+      val l1 = Labels.alpha
+      val l2 = Labels.alpha
+
+      l1 assertEQ l2
+      l2 assertEQ l1
+    }
+
+    withClue("LT/GT") {
+      val l1 = Labels.alpha
+      val l2 = Labels.alpha(1)
+
+      l1 assertLT l2
+      l2 assertGT l1
+    }
+  }
+
+  behavior of "semver label beta-singleton"
+
+  it should "only equal beta singleton < beta" in {
+    withClue("EQ") {
+      val l1 = Labels.beta
+      val l2 = Labels.beta
+
+      l1 assertEQ l2
+      l2 assertEQ l1
+    }
+
+    withClue("LT/GT") {
+      val l1 = Labels.beta
+      val l2 = Labels.beta(1)
+
+      l1 assertLT l2
+      l2 assertGT l1
+    }
+  }
+
+
+  behavior of "semver label beta"
+
+  it should "be the same as Int natural ordering when comparing with other betas" in {
+    withClue("EQ") {
+      val l1 = Labels.beta(1)
+      val l2 = Labels.beta(1)
+
+      l1 assertEQ l2
+      l2 assertEQ l1
+    }
+
+    withClue("LT/GT") {
+      val l1 = Labels.beta(1)
+      val l2 = Labels.beta(2)
+
+      l1 assertLT l2
+      l2 assertGT l1
+    }
+  }
+
+
+  it should "be the same as Int natural ordering when comparing with other Ms" in {
+    withClue("EQ") {
+      val l1 = Labels.m(1)
+      val l2 = Labels.m(1)
+
+      l1 assertEQ l2
+      l2 assertEQ l1
+    }
+
+    withClue("LT/GT") {
+      val l1 = Labels.m(1)
+      val l2 = Labels.m(2)
+
+      l1 assertLT l2
+      l2 assertGT l1
+    }
+  }
+
+  it should "be the same as Int natural ordering when comparing with other RCs" in {
+    withClue("EQ") {
+      val l1 = Labels.rc(1)
+      val l2 = Labels.rc(1)
+
+      l1 assertEQ l2
+      l2 assertEQ l1
+    }
+
+    withClue("LT/GT") {
+      val l1 = Labels.rc(1)
+      val l2 = Labels.rc(2)
+
+      l1 assertLT l2
+      l2 assertGT l1
+    }
+  }
+
+  behavior of "semver label truth table"
+
+  it should "work wrt to all possible combinations of types, and EQ/LT/GT operators" in {
+    val snapshotLabel = Labels.snapshot
+    val alphaSingle = Labels.alpha
+    val alphaLabel = Labels.alpha(1)
+    val betaSingle = Labels.beta
+    val betaLabel = Labels.beta(1)
+    val mLabel = Labels.m(1)
+    val rcLabel = Labels.rc(1)
+
+    withClue("snapshot") {
+      snapshotLabel assertEQ snapshotLabel
+      snapshotLabel assertLT alphaSingle
+      snapshotLabel assertLT alphaLabel
+      snapshotLabel assertLT betaSingle
+      snapshotLabel assertLT betaLabel
+      snapshotLabel assertLT mLabel
+      snapshotLabel assertLT rcLabel
+
+      snapshotLabel assertEQ snapshotLabel
+      alphaSingle assertGT snapshotLabel
+      alphaLabel assertGT snapshotLabel
+      betaSingle assertGT snapshotLabel
+      betaLabel assertGT snapshotLabel
+      mLabel assertGT snapshotLabel
+      rcLabel assertGT snapshotLabel
+    }
+
+    withClue("alpha-single") {
+      alphaSingle assertGT snapshotLabel
+      alphaSingle assertEQ alphaSingle
+      alphaSingle assertLT alphaLabel
+      alphaSingle assertLT betaSingle
+      alphaSingle assertLT betaLabel
+      alphaSingle assertLT mLabel
+      alphaSingle assertLT rcLabel
+
+      snapshotLabel assertLT alphaSingle
+      alphaSingle assertEQ alphaSingle
+      alphaLabel assertGT alphaSingle
+      betaSingle assertGT alphaSingle
+      betaLabel assertGT alphaSingle
+      mLabel assertGT alphaSingle
+      rcLabel assertGT alphaSingle
+    }
+
+    withClue("alpha") {
+      alphaLabel assertGT snapshotLabel
+      alphaLabel assertGT alphaSingle
+      alphaLabel assertEQ alphaLabel
+      alphaLabel assertLT betaSingle
+      alphaLabel assertLT betaLabel
+      alphaLabel assertLT mLabel
+      alphaLabel assertLT rcLabel
+
+      snapshotLabel assertLT alphaLabel
+      alphaSingle assertLT alphaLabel
+      alphaLabel assertEQ alphaLabel
+      betaSingle assertGT alphaLabel
+      betaLabel assertGT alphaLabel
+      mLabel assertGT alphaLabel
+      rcLabel assertGT alphaLabel
+    }
+
+    withClue("beta-single") {
+      betaSingle assertGT snapshotLabel
+      betaSingle assertGT alphaLabel
+      betaSingle assertEQ betaSingle
+      betaSingle assertLT betaLabel
+      betaSingle assertLT mLabel
+      betaSingle assertLT rcLabel
+
+      snapshotLabel assertLT betaSingle
+      alphaLabel assertLT betaSingle
+      betaSingle assertEQ betaSingle
+      betaLabel assertGT betaSingle
+      mLabel assertGT betaSingle
+      rcLabel assertGT betaSingle
+    }
+
+    withClue("beta") {
+      betaLabel assertGT snapshotLabel
+      betaLabel assertGT alphaLabel
+      betaLabel assertGT betaSingle
+      betaLabel assertEQ betaLabel
+      betaLabel assertLT mLabel
+      betaLabel assertLT rcLabel
+
+      snapshotLabel assertLT betaLabel
+      alphaLabel assertLT betaLabel
+      betaSingle assertLT betaLabel
+      betaLabel assertEQ betaLabel
+      mLabel assertGT betaLabel
+      rcLabel assertGT betaLabel
+    }
+
+    withClue("M") {
+      mLabel assertGT snapshotLabel
+      mLabel assertGT alphaSingle
+      mLabel assertGT alphaLabel
+      mLabel assertGT betaSingle
+      mLabel assertGT betaLabel
+      mLabel assertEQ mLabel
+      mLabel assertLT rcLabel
+
+      snapshotLabel assertLT mLabel
+      alphaSingle assertLT mLabel
+      alphaLabel assertLT mLabel
+      betaSingle assertLT mLabel
+      betaLabel assertLT mLabel
+      mLabel assertEQ mLabel
+      rcLabel assertGT mLabel
+    }
+
+    withClue("RC") {
+      rcLabel assertGT snapshotLabel
+      rcLabel assertGT alphaSingle
+      rcLabel assertGT alphaLabel
+      rcLabel assertGT betaSingle
+      rcLabel assertGT betaLabel
+      rcLabel assertGT mLabel
+      rcLabel assertEQ rcLabel
+
+      snapshotLabel assertLT rcLabel
+      alphaSingle assertLT rcLabel
+      alphaLabel assertLT rcLabel
+      betaSingle assertLT rcLabel
+      betaLabel assertLT rcLabel
+      mLabel assertLT rcLabel
+      rcLabel assertEQ rcLabel
+    }
+  }
+}

--- a/semver/src/test/scala/busymachines/semver/SemanticVersionOrderingTest.scala
+++ b/semver/src/test/scala/busymachines/semver/SemanticVersionOrderingTest.scala
@@ -1,0 +1,235 @@
+package busymachines.semver
+
+import org.scalatest.{FlatSpec, Matchers}
+
+/**
+  *
+  * @author Lorand Szakacs, lsz@lorandszakacs.com, lorand.szakacs@busymachines.com
+  * @since 10 Nov 2017
+  *
+  */
+class SemanticVersionOrderingTest extends FlatSpec with Matchers {
+
+  //technically I could have used >, ==, < operators as well
+  private implicit class SemVerTestOps(sv: SemanticVersion) {
+    def assertGT(that: SemanticVersion): Unit = {
+      assert(sv.compareTo(that) > 0, s"$sv should be greater than $that")
+    }
+
+    def assertEQ(that: SemanticVersion): Unit = {
+      assert(sv.compareTo(that) == 0, s"$sv should be equal to $that")
+    }
+
+    def assertLT(that: SemanticVersion): Unit = {
+      assert(sv.compareTo(that) < 0, s"$sv should be less than $that")
+    }
+  }
+
+  behavior of "SemanticVersion ordering"
+
+  it should "be equal w/ label" in {
+    val v1 = SemanticVersion(1, 0, 0, Labels.rc(1))
+    val v2 = SemanticVersion(1, 0, 0, Labels.rc(1))
+
+    v1 assertEQ v2
+    v2 assertEQ v1
+  }
+
+  it should "be equal w/o label" in {
+    val v1 = SemanticVersion(1, 0, 0)
+    val v2 = SemanticVersion(1, 0, 0)
+
+    v1 assertEQ v2
+  }
+
+  it should "properly compare when major dominates w/ label" in {
+    val v1 = SemanticVersion(1, 0, 0, Labels.rc(1))
+    val v2 = SemanticVersion(2, 0, 0, Labels.rc(1))
+
+    v1 assertLT v2
+    v2 assertGT v1
+  }
+
+  it should "properly compare when major dominates w/o label" in {
+    val v1 = SemanticVersion(1, 0, 0)
+    val v2 = SemanticVersion(2, 0, 0)
+
+    v1 assertLT v2
+    v2 assertGT v1
+  }
+
+  it should "properly compare when minor dominates w/ label" in {
+    val v1 = SemanticVersion(1, 0, 0, Labels.rc(1))
+    val v2 = SemanticVersion(1, 1, 0, Labels.rc(1))
+
+    v1 assertLT v2
+    v2 assertGT v1
+  }
+
+  it should "properly compare when minor dominates w/o label" in {
+    val v1 = SemanticVersion(1, 0, 0)
+    val v2 = SemanticVersion(1, 1, 0)
+
+    v1 assertLT v2
+    v2 assertGT v1
+  }
+
+  it should "properly compare when patch dominates w/ label" in {
+    val v1 = SemanticVersion(1, 0, 0, Labels.rc(1))
+    val v2 = SemanticVersion(1, 0, 1, Labels.rc(1))
+
+    v1 assertLT v2
+    v2 assertGT v1
+  }
+
+  it should "properly compare when patch dominates w/o label" in {
+    val v1 = SemanticVersion(1, 0, 0)
+    val v2 = SemanticVersion(1, 0, 1)
+
+    v1 assertLT v2
+    v2 assertGT v1
+  }
+
+  it should "properly compare when label dominates — snapshot < alpha < beta < RC < M" in {
+    val snapshot = SemanticVersion(1, 0, 0, Labels.snapshot)
+    val alpha = SemanticVersion(1, 0, 0, Labels.alpha(4))
+    val beta = SemanticVersion(1, 0, 0, Labels.beta(3))
+    val m = SemanticVersion(1, 0, 0, Labels.m(2))
+    val rc = SemanticVersion(1, 0, 0, Labels.rc(1))
+
+    withClue("snapshot") {
+      snapshot assertEQ snapshot
+      snapshot assertLT alpha
+      snapshot assertLT beta
+      snapshot assertLT m
+      snapshot assertLT rc
+
+      snapshot assertEQ snapshot
+      alpha assertGT snapshot
+      beta assertGT snapshot
+      m assertGT snapshot
+      rc assertGT snapshot
+    }
+
+    withClue("alpha") {
+      alpha assertGT snapshot
+      alpha assertEQ alpha
+      alpha assertLT beta
+      alpha assertLT m
+      alpha assertLT rc
+
+      snapshot assertLT alpha
+      alpha assertEQ alpha
+      beta assertGT alpha
+      m assertGT alpha
+      rc assertGT alpha
+    }
+
+    withClue("beta") {
+      beta assertGT snapshot
+      beta assertGT alpha
+      beta assertEQ beta
+      beta assertLT m
+      beta assertLT rc
+
+      snapshot assertLT beta
+      alpha assertLT beta
+      beta assertEQ beta
+      m assertGT beta
+      rc assertGT beta
+    }
+
+    withClue("M") {
+      m assertGT snapshot
+      m assertGT alpha
+      m assertGT beta
+      m assertEQ m
+      m assertLT rc
+
+      snapshot assertLT m
+      alpha assertLT m
+      beta assertLT m
+      m assertEQ m
+      rc assertGT m
+    }
+
+    withClue("RC") {
+      rc assertGT snapshot
+      rc assertGT alpha
+      rc assertGT beta
+      rc assertGT m
+      rc assertEQ rc
+
+      snapshot assertLT rc
+      alpha assertLT rc
+      beta assertLT rc
+      m assertLT rc
+      rc assertEQ rc
+    }
+  }
+
+  it should "properly compare when label dominates — same label — alpha" in {
+    val v1 = SemanticVersion(1, 0, 0, Labels.alpha(1))
+    val v2 = SemanticVersion(1, 0, 0, Labels.alpha(2))
+
+    v1 assertLT v2
+    v2 assertGT v1
+  }
+
+  it should "properly compare when label dominates — same label — alpha — 1 < 10" in {
+    val v1 = SemanticVersion(1, 0, 0, Labels.alpha(1))
+    val v2 = SemanticVersion(1, 0, 0, Labels.alpha(11))
+
+    v1 assertLT v2
+    v2 assertGT v1
+  }
+
+  it should "properly compare when label dominates — same label — beta" in {
+    val v1 = SemanticVersion(1, 0, 0, Labels.beta(1))
+    val v2 = SemanticVersion(1, 0, 0, Labels.beta(2))
+
+    v1 assertLT v2
+    v2 assertGT v1
+  }
+
+  it should "properly compare when label dominates — same label — beta — 1 < 10" in {
+    val v1 = SemanticVersion(1, 0, 0, Labels.beta(1))
+    val v2 = SemanticVersion(1, 0, 0, Labels.beta(11))
+
+    v1 assertLT v2
+    v2 assertGT v1
+  }
+
+  it should "properly compare when label dominates — same label — RC" in {
+    val v1 = SemanticVersion(1, 0, 0, Labels.rc(1))
+    val v2 = SemanticVersion(1, 0, 0, Labels.rc(2))
+
+    v1 assertLT v2
+    v2 assertGT v1
+  }
+
+  it should "properly compare when label dominates — same label — RC — 1 < 10" in {
+    val v1 = SemanticVersion(1, 0, 0, Labels.rc(1))
+    val v2 = SemanticVersion(1, 0, 0, Labels.rc(11))
+
+    v1 assertLT v2
+    v2 assertGT v1
+  }
+
+  it should "properly compare when label dominates — same label — M" in {
+    val v1 = SemanticVersion(1, 0, 0, Labels.m(1))
+    val v2 = SemanticVersion(1, 0, 0, Labels.m(2))
+
+    v1 assertLT v2
+    v2 assertGT v1
+  }
+
+  it should "properly compare when label dominates — same label — M — 1 < 10" in {
+    val v1 = SemanticVersion(1, 0, 0, Labels.m(1))
+    val v2 = SemanticVersion(1, 0, 0, Labels.m(11))
+
+    v1 assertLT v2
+    v2 assertGT v1
+  }
+
+}

--- a/semver/src/test/scala/busymachines/semver/SemanticVersionShowsTest.scala
+++ b/semver/src/test/scala/busymachines/semver/SemanticVersionShowsTest.scala
@@ -1,0 +1,184 @@
+package busymachines.semver
+
+import org.scalatest.{FlatSpec, Matchers}
+
+/**
+  *
+  * @author Lorand Szakacs, lsz@lorandszakacs.com, lorand.szakacs@busymachines.com
+  * @since 13 Nov 2017
+  *
+  */
+class SemanticVersionShowsTest extends FlatSpec with Matchers {
+
+  val snapshot = SemanticVersion(1, 0, 0, Labels.snapshot)
+  val alphaSingle = SemanticVersion(1, 0, 0, Labels.alpha)
+  val alpha1 = SemanticVersion(1, 0, 0, Labels.alpha(1))
+  val betaSingle = SemanticVersion(1, 0, 0, Labels.beta)
+  val beta1 = SemanticVersion(1, 0, 0, Labels.beta(1))
+  val m1 = SemanticVersion(1, 0, 0, Labels.m(1))
+  val rc1 = SemanticVersion(1, 0, 0, Labels.rc(1))
+
+  val snapshotWMeta = SemanticVersion(1, 0, 0, Labels.snapshot, Option("1111"))
+  val alphaSingleWMeta = SemanticVersion(1, 0, 0, Labels.alpha, Option("2222"))
+  val alpha1WMeta = SemanticVersion(1, 0, 0, Labels.alpha(1), Option("3333"))
+  val betaSingleWMeta = SemanticVersion(1, 0, 0, Labels.beta, Option("4444"))
+  val beta1WMeta = SemanticVersion(1, 0, 0, Labels.beta(1), Option("5555"))
+  val m1WMeta = SemanticVersion(1, 0, 0, Labels.m(1), Option("6666"))
+  val rc1WMeta = SemanticVersion(1, 0, 0, Labels.rc(1), Option("7777"))
+
+  val snapshotWOLabelWMeta = SemanticVersion(1, 0, 0, None, Option("1111"))
+  val alphaSingleWOLabelWMeta = SemanticVersion(1, 0, 0, None, Option("2222"))
+  val alpha1WOLabelWMeta = SemanticVersion(1, 0, 0, None, Option("3333"))
+  val betaSingleWOLabelWMeta = SemanticVersion(1, 0, 0, None, Option("4444"))
+  val beta1WOLabelWMeta = SemanticVersion(1, 0, 0, None, Option("5555"))
+  val m1WOLabelWMeta = SemanticVersion(1, 0, 0, None, Option("6666"))
+  val rc1WOLabelWMeta = SemanticVersion(1, 0, 0, None, Option("7777"))
+
+  behavior of "lowercase, no separator show"
+
+  it should "properly display with w/o label, w/o meta" in {
+    val v1 = SemanticVersion(1, 0, 0)
+    assert(v1.lowercase == "1.0.0")
+  }
+
+  it should "properly display with w/ label, no meta" in {
+    assert(snapshot.lowercase == "1.0.0-snapshot")
+    assert(alphaSingle.lowercase == "1.0.0-alpha")
+    assert(alpha1.lowercase == "1.0.0-alpha1")
+    assert(betaSingle.lowercase == "1.0.0-beta")
+    assert(beta1.lowercase == "1.0.0-beta1")
+    assert(m1.lowercase == "1.0.0-m1")
+    assert(rc1.lowercase == "1.0.0-rc1")
+  }
+
+  it should "properly display with w/ label, w/ meta" in {
+    assert(snapshotWMeta.lowercase == "1.0.0-snapshot+1111")
+    assert(alphaSingleWMeta.lowercase == "1.0.0-alpha+2222")
+    assert(alpha1WMeta.lowercase == "1.0.0-alpha1+3333")
+    assert(betaSingleWMeta.lowercase == "1.0.0-beta+4444")
+    assert(beta1WMeta.lowercase == "1.0.0-beta1+5555")
+    assert(m1WMeta.lowercase == "1.0.0-m1+6666")
+    assert(rc1WMeta.lowercase == "1.0.0-rc1+7777")
+  }
+
+  it should "properly display with w/o label, w/ meta" in {
+    assert(snapshotWOLabelWMeta.lowercase == "1.0.0+1111")
+    assert(alphaSingleWOLabelWMeta.lowercase == "1.0.0+2222")
+    assert(alpha1WOLabelWMeta.lowercase == "1.0.0+3333")
+    assert(betaSingleWOLabelWMeta.lowercase == "1.0.0+4444")
+    assert(beta1WOLabelWMeta.lowercase == "1.0.0+5555")
+    assert(m1WOLabelWMeta.lowercase == "1.0.0+6666")
+    assert(rc1WOLabelWMeta.lowercase == "1.0.0+7777")
+  }
+
+  behavior of "lowercase, dot separator show"
+
+  it should "properly display with w/o label, w/o meta" in {
+    val v1 = SemanticVersion(1, 0, 0)
+    assert(v1.lowercaseWithDots == "1.0.0")
+  }
+
+  it should "properly display with w/ label, no meta" in {
+    assert(snapshot.lowercaseWithDots == "1.0.0-snapshot")
+    assert(alphaSingle.lowercaseWithDots == "1.0.0-alpha")
+    assert(alpha1.lowercaseWithDots == "1.0.0-alpha.1")
+    assert(betaSingle.lowercaseWithDots == "1.0.0-beta")
+    assert(beta1.lowercaseWithDots == "1.0.0-beta.1")
+    assert(m1.lowercaseWithDots == "1.0.0-m.1")
+    assert(rc1.lowercaseWithDots == "1.0.0-rc.1")
+  }
+
+  it should "properly display with w/ label, w/ meta" in {
+    assert(snapshotWMeta.lowercaseWithDots == "1.0.0-snapshot+1111")
+    assert(alphaSingleWMeta.lowercaseWithDots == "1.0.0-alpha+2222")
+    assert(alpha1WMeta.lowercaseWithDots == "1.0.0-alpha.1+3333")
+    assert(betaSingleWMeta.lowercaseWithDots == "1.0.0-beta+4444")
+    assert(beta1WMeta.lowercaseWithDots == "1.0.0-beta.1+5555")
+    assert(m1WMeta.lowercaseWithDots == "1.0.0-m.1+6666")
+    assert(rc1WMeta.lowercaseWithDots == "1.0.0-rc.1+7777")
+  }
+
+  it should "properly display with w/o label, w/ meta" in {
+    assert(snapshotWOLabelWMeta.lowercaseWithDots == "1.0.0+1111")
+    assert(alphaSingleWOLabelWMeta.lowercaseWithDots == "1.0.0+2222")
+    assert(alpha1WOLabelWMeta.lowercaseWithDots == "1.0.0+3333")
+    assert(betaSingleWOLabelWMeta.lowercaseWithDots == "1.0.0+4444")
+    assert(beta1WOLabelWMeta.lowercaseWithDots == "1.0.0+5555")
+    assert(m1WOLabelWMeta.lowercaseWithDots == "1.0.0+6666")
+    assert(rc1WOLabelWMeta.lowercaseWithDots == "1.0.0+7777")
+  }
+
+  behavior of "uppercase, no separator show"
+
+  it should "properly display with w/o label, w/o meta" in {
+    val v1 = SemanticVersion(1, 0, 0)
+    assert(v1.uppercase == "1.0.0")
+  }
+
+  it should "properly display with w/ label, no meta" in {
+    assert(snapshot.uppercase == "1.0.0-SNAPSHOT")
+    assert(alphaSingle.uppercase == "1.0.0-ALPHA")
+    assert(alpha1.uppercase == "1.0.0-ALPHA1")
+    assert(betaSingle.uppercase == "1.0.0-BETA")
+    assert(beta1.uppercase == "1.0.0-BETA1")
+    assert(m1.uppercase == "1.0.0-M1")
+    assert(rc1.uppercase == "1.0.0-RC1")
+  }
+
+  it should "properly display with w/ label, w/ meta" in {
+    assert(snapshotWMeta.uppercase == "1.0.0-SNAPSHOT+1111")
+    assert(alphaSingleWMeta.uppercase == "1.0.0-ALPHA+2222")
+    assert(alpha1WMeta.uppercase == "1.0.0-ALPHA1+3333")
+    assert(betaSingleWMeta.uppercase == "1.0.0-BETA+4444")
+    assert(beta1WMeta.uppercase == "1.0.0-BETA1+5555")
+    assert(m1WMeta.uppercase == "1.0.0-M1+6666")
+    assert(rc1WMeta.uppercase == "1.0.0-RC1+7777")
+  }
+
+  it should "properly display with w/o label, w/ meta" in {
+    assert(snapshotWOLabelWMeta.uppercase == "1.0.0+1111")
+    assert(alphaSingleWOLabelWMeta.uppercase == "1.0.0+2222")
+    assert(alpha1WOLabelWMeta.uppercase == "1.0.0+3333")
+    assert(betaSingleWOLabelWMeta.uppercase == "1.0.0+4444")
+    assert(beta1WOLabelWMeta.uppercase == "1.0.0+5555")
+    assert(m1WOLabelWMeta.uppercase == "1.0.0+6666")
+    assert(rc1WOLabelWMeta.uppercase == "1.0.0+7777")
+  }
+
+  behavior of "uppercase, dot separator show"
+
+  it should "properly display with w/o label, w/o meta" in {
+    val v1 = SemanticVersion(1, 0, 0)
+    assert(v1.uppercaseWithDots == "1.0.0")
+  }
+
+  it should "properly display with w/ label, no meta" in {
+    assert(snapshot.uppercaseWithDots == "1.0.0-SNAPSHOT")
+    assert(alphaSingle.uppercaseWithDots == "1.0.0-ALPHA")
+    assert(alpha1.uppercaseWithDots == "1.0.0-ALPHA.1")
+    assert(betaSingle.uppercaseWithDots == "1.0.0-BETA")
+    assert(beta1.uppercaseWithDots == "1.0.0-BETA.1")
+    assert(m1.uppercaseWithDots == "1.0.0-M.1")
+    assert(rc1.uppercaseWithDots == "1.0.0-RC.1")
+  }
+
+  it should "properly display with w/ label, w/ meta" in {
+    assert(snapshotWMeta.uppercaseWithDots == "1.0.0-SNAPSHOT+1111")
+    assert(alphaSingleWMeta.uppercaseWithDots == "1.0.0-ALPHA+2222")
+    assert(alpha1WMeta.uppercaseWithDots == "1.0.0-ALPHA.1+3333")
+    assert(betaSingleWMeta.uppercaseWithDots == "1.0.0-BETA+4444")
+    assert(beta1WMeta.uppercaseWithDots == "1.0.0-BETA.1+5555")
+    assert(m1WMeta.uppercaseWithDots == "1.0.0-M.1+6666")
+    assert(rc1WMeta.uppercaseWithDots == "1.0.0-RC.1+7777")
+  }
+
+  it should "properly display with w/o label, w/ meta" in {
+    assert(snapshotWOLabelWMeta.uppercaseWithDots == "1.0.0+1111")
+    assert(alphaSingleWOLabelWMeta.uppercaseWithDots == "1.0.0+2222")
+    assert(alpha1WOLabelWMeta.uppercaseWithDots == "1.0.0+3333")
+    assert(betaSingleWOLabelWMeta.uppercaseWithDots == "1.0.0+4444")
+    assert(beta1WOLabelWMeta.uppercaseWithDots == "1.0.0+5555")
+    assert(m1WOLabelWMeta.uppercaseWithDots == "1.0.0+6666")
+    assert(rc1WOLabelWMeta.uppercaseWithDots == "1.0.0+7777")
+  }
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.0-RC5"
+version in ThisBuild := "0.2.0-RC6"


### PR DESCRIPTION
Add `semver` and `semver-parsers` modules.

- [x] add `SemanticVersion` datatype with natural ordering as specified by the Semantic Version 2.0.0 [specification](http://semver.org/)
- [x] add stringy methods to SemanticVersions
- [x] add parsers to read the stringy representation from above
- [x] test properly