### PR TITLE
Prepare 0.2.0-RC8

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Probably due to an missing implicit — probably automatic derivation of some ty
 
 #### versions
 * stable: `0.1.0` — but almost useless
-* latest: `0.2.0-RC7`
+* latest: `0.2.0-RC8`
 
 These modules are are cross-compiled for Scala versions: `2.12.3`. We try our best to keep them up to date.
 
@@ -50,7 +50,7 @@ Module | Description | Version
 
 For easy copy-pasting:
 ```scala
-val bmcVersion: String = "0.2.0-RC7"
+val bmcVersion: String = "0.2.0-RC8"
 
 val bmcCore            = "com.busymachines" %% "busymachines-commons-core" % bmcVersion
 val bmcJson            = "com.busymachines" %% "busymachines-commons-json" % bmcVersion
@@ -78,17 +78,17 @@ The idea behind these sets of libraries is to help jumpstart backend RESTful api
 Basically, as long as modules reside in the same repository they will be versioned with the same number, and released at the same time to avoid confusion. The moment we realize that a module has to take a life of its own, it will be moved to a separate module and versioned independently.
 
 * [core](/core) `0.1.0`
-* [json](/json) `0.2.0-RC7`
-* [rest-core](/rest-core) `0.2.0-RC7` - this is an abstract implementation that still requires specific serialization/deserialization
-* [rest-core-testkit](/rest-core-testkit) `0.2.0-RC7` - contains helpers that allow testing. Should never wind up in production code.
-* [rest-json](/rest-core) `0.2.0-RC7` - used to implement REST APIs that handle JSON
-* [rest-json-testkit](/rest-json-testkit) `0.2.0-RC7` - helpers for JSON powered REST APIs
+* [json](/json) `0.2.0-RC8`
+* [rest-core](/rest-core) `0.2.0-RC8` - this is an abstract implementation that still requires specific serialization/deserialization
+* [rest-core-testkit](/rest-core-testkit) `0.2.0-RC8` - contains helpers that allow testing. Should never wind up in production code.
+* [rest-json](/rest-core) `0.2.0-RC8` - used to implement REST APIs that handle JSON
+* [rest-json-testkit](/rest-json-testkit) `0.2.0-RC8` - helpers for JSON powered REST APIs
 
 Most likely you don't need to depend on the `rest-core*` modules. But rather on one or more of its reifications like `rest-json`. This separation was done because in the future we might need non-json REST APIs, and then we still want to have a common experience of using `commons`.
 
 Other modules:
-* [semver](/semver) `0.2.0-RC7` - definition of a `SemanticVersion` datatype and its natural ordering according to the [Semantic Version 2.0.0](http://semver.org/) spec. Useful only if you have to manipulate semantic versions in your code. No other modules here depend on it.
-* [semver](/semver-parsers) `0.2.0-RC7` - parsers from plain string to the above `SemanticVersion`.
+* [semver](/semver) `0.2.0-RC8` - definition of a `SemanticVersion` datatype and its natural ordering according to the [Semantic Version 2.0.0](http://semver.org/) spec. Useful only if you have to manipulate semantic versions in your code. No other modules here depend on it.
+* [semver](/semver-parsers) `0.2.0-RC8` - parsers from plain string to the above `SemanticVersion`.
 
 ### Current version
 

--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,10 @@ addCommandAlias("doSnapshotLocal", ";clean;update;compile;setSnapshotVersion;pub
 /**
   * Use with care. Releases a snapshot to sonatype repository.
   *
+  * Currently this will not work properly because of an SBT bug where
+  * the artifacts are not overriden in the SONATYPE repo:
+  * https://github.com/sbt/sbt/issues/3725
+  *
   * All instructions for publishing to sonatype can be found in
   * ``z-publishing-artifcats/README.md``.
   */

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,11 @@ import Keys._
 addCommandAlias("ci", ";clean;update;compile;test:compile;test")
 
 /**
+  * Quick handy way of publishing locally.
+  */
+addCommandAlias("doLocal", ";clean;update;compile;publishLocal")
+
+/**
   * Use with care.
   *
   * All instructions for publishing to sonatype can be found in

--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,23 @@
 import sbt._
 import Keys._
 
+lazy val currentSnapshotVersion = "0.2.0-SNAPSHOT"
+
+addCommandAlias("setSnapshotVersion", s"""set version in ThisBuild := "$currentSnapshotVersion"""")
+
 addCommandAlias("ci", ";clean;update;compile;test:compile;test")
 
-/**
-  * Quick handy way of publishing locally.
-  */
 addCommandAlias("doLocal", ";clean;update;compile;publishLocal")
+
+addCommandAlias("doSnapshotLocal", ";clean;update;compile;setSnapshotVersion;publishLocal")
+
+/**
+  * Use with care. Releases a snapshot to sonatype repository.
+  *
+  * All instructions for publishing to sonatype can be found in
+  * ``z-publishing-artifcats/README.md``.
+  */
+addCommandAlias("doSnapshotRelease", ";ci;setSnapshotVersion;publishSigned")
 
 /**
   * Use with care.
@@ -15,14 +26,6 @@ addCommandAlias("doLocal", ";clean;update;compile;publishLocal")
   * ``z-publishing-artifcats/README.md``.
   */
 addCommandAlias("doRelease", ";ci;publishSigned;sonatypeRelease")
-
-/**
-  * this is used when a module depends on another, and it explicitly
-  * states that the "compile", i.e. the sources, of a module depend
-  * on the sources of another module. And the same thing for tests,
-  * otherwise the dependencies between the tests are not created.
-  */
-val `compile->compile;test->test` = "compile->compile;test->test"
 
 /**
   * this is a phantom project that is simply supposed to aggregate all modules for convenience,

--- a/build.sbt
+++ b/build.sbt
@@ -1,14 +1,15 @@
 import sbt._
 import Keys._
 
-/**
-  * * All instructions for publishing to sonatype can be found in the
-  * ``z-publishing-artifcats/README.md`` folder.
-  *
-  * @author Lorand Szakacs, lsz@lorandszakacs.com, lorand.szakacs@busymachines.com
-  * @since 31 Jul 2017
-  */
+addCommandAlias("ci", ";clean;update;compile;test:compile;test")
 
+/**
+  * Use with care.
+  *
+  * All instructions for publishing to sonatype can be found in
+  * ``z-publishing-artifcats/README.md``.
+  */
+addCommandAlias("doRelease", ";ci;publishSigned;sonatypeRelease")
 
 /**
   * this is used when a module depends on another, and it explicitly

--- a/core/README.md
+++ b/core/README.md
@@ -62,18 +62,18 @@ option.getOrElse(throw NotFoundFailure("this specific message, instead of generi
 ```scala
 object RevolutionaryDomainFailures {
   //create a stable, and unique ID
-  case object CannotBeDone extends FailureID { val name = "rd_001" }
+  case object CannotBeDone extends AnomalyID { val name = "rd_001" }
 }
 
 case class SolutionNotFoundFailure(problem: String, attempts: Seq[String]) extends NotFoundFailure(
   s"Solution to problem $problem not found."
 ) {
-  override def id: FailureID = RevolutionaryDomainFailures.CannotBeDone
+  override def id: AnomalyID = RevolutionaryDomainFailures.CannotBeDone
 
   //you can currently associate (String, String), (String, Seq[String])
   //this compiles because of the implicit conversions in the DSL
   //these implicit conversions can be removed when Dotty comes out
-  override def parameters: Parameters = Map(
+  override def parameters: Anomaly.Parameters = Map(
     "problem" -> problem,
     "attempts" -> attempts
   )
@@ -81,10 +81,10 @@ case class SolutionNotFoundFailure(problem: String, attempts: Seq[String]) exten
 
 object Main {
   //...
-  val solutionToPVSNP: Option[Boolean] = ???
+  val solutionToPVSNP: Option[Boolean] = None
   solutionToPVSNP.getOrElse(throw SolutionNotFoundFailure("P vs. NP", Seq("1", "2", "3")))
 
-  val solutionToHaltingProblem: Option[Boolean] = ???
+  val solutionToHaltingProblem: Option[Boolean] = None
   solutionToHaltingProblem.getOrElse(throw SolutionNotFoundFailure("Halting Problem", Seq("stop", "12")))
 }
 ```

--- a/core/README.md
+++ b/core/README.md
@@ -13,10 +13,31 @@ The full module id is:
 
 Here you find very basic buildings blocks for structuring your exceptions in meaningful ways, and very basic types. Generally, we are very conservative in what we put here, and this core will become stable really fast.
 
-## Failures (exceptions) and Errors
+## Anomaly (exception) and Catastrophe (error)
+
+There's nothing special about anomaly, and catastrophe, other than the fact they try to represent "pure" failures. They are traits with no pretenses of being thrown around, once they are transformed into a throwable, they become a "Failure".
+
+Why should you use them?
+Because they can provide decent failure management out of the box. Use in combination with the `rest` modules, you can move with almost zero effort to meaningful error messages.
+
+The Anomaly trait, the base class for everything in `core`:
+```scala
+trait Anomaly extends Product with Serializable {
+  def id: AnomalyID
+
+  def message: String
+
+  def parameters: Anomaly.Parameters = Anomaly.Parameters.empty
+
+  //important scaladoc elided
+  def asThrowable: Throwable
+}
+```
+
+A simple way of uniquely identifying any failure, together with some useful values to give more context.
 
 This library provides a `DSL` (although it's a bit of a stretch to call it that) to define, and instantiate semantically rich failures.
-Look at the scaladoc in [failures.scala](src/main/scala/com/busymachines/core/exceptions/failures.scala) for more information.
+Look at the scaladoc in [anomaly.scala](src/main/scala/com/busymachines/core/anomaly.scala) for more information.
 Essentially we have 6 types of failures (with a plural counterpart to each):
 
 * `NotFoundFailure`

--- a/core/README.md
+++ b/core/README.md
@@ -7,7 +7,7 @@
 This module is vanilla scala _*only*_, cross-compiled against versions: `2.12.3`.
 
 The full module id is:
-`"com.busymachines" %% "busymachines-commons-core" % "0.2.0-RC7"`
+`"com.busymachines" %% "busymachines-commons-core" % "0.2.0-RC8"`
 
 ## Description
 

--- a/core/src/main/scala/busymachines/core/anomalies.scala
+++ b/core/src/main/scala/busymachines/core/anomalies.scala
@@ -46,6 +46,13 @@ abstract class AnomalousFailures(
   override val restOfAnomalies: immutable.Seq[Anomaly],
 ) extends AnomalousFailure(message) with Anomalies with Product with Serializable
 
+object AnomalousFailures {
+
+  def apply(id: AnomalyID, message: String, msg: Anomaly, msgs: Anomaly*): AnomalousFailures = {
+    AnomalousFailuresImpl(id, message, msg, msgs.toList)
+  }
+}
+
 private[core] case class AnomalousFailuresImpl(
   override val id:              AnomalyID,
   override val message:         String,

--- a/core/src/main/scala/busymachines/core/anomalies.scala
+++ b/core/src/main/scala/busymachines/core/anomalies.scala
@@ -1,0 +1,54 @@
+package busymachines.core
+
+import scala.collection.immutable
+
+/**
+  *
+  * @author Lorand Szakacs, lsz@lorandszakacs.com, lorand.szakacs@busymachines.com
+  * @since 26 Dec 2017
+  *
+  */
+trait Anomalies extends Anomaly with Product with Serializable {
+  def firstAnomaly: Anomaly
+
+  def restOfAnomalies: immutable.Seq[Anomaly]
+
+  final def messages: immutable.Seq[Anomaly] =
+    firstAnomaly +: restOfAnomalies
+}
+
+object Anomalies {
+
+  def apply(id: AnomalyID, message: String, msg: Anomaly, msgs: Anomaly*): Anomalies = {
+    AnomaliesImpl(id, message, msg, msgs.toList)
+  }
+}
+
+private[core] final case class AnomaliesImpl(
+  override val id:              AnomalyID,
+  override val message:         String,
+  override val firstAnomaly:    Anomaly,
+  override val restOfAnomalies: immutable.Seq[Anomaly],
+) extends Anomalies {
+
+  override def asThrowable: Throwable = AnomalousFailuresImpl(
+    id,
+    message,
+    firstAnomaly,
+    restOfAnomalies
+  )
+}
+
+abstract class AnomalousFailures(
+  override val id:              AnomalyID,
+  override val message:         String,
+  override val firstAnomaly:    Anomaly,
+  override val restOfAnomalies: immutable.Seq[Anomaly],
+) extends AnomalousFailure(message) with Anomalies with Product with Serializable
+
+private[core] case class AnomalousFailuresImpl(
+  override val id:              AnomalyID,
+  override val message:         String,
+  override val firstAnomaly:    Anomaly,
+  override val restOfAnomalies: immutable.Seq[Anomaly],
+) extends AnomalousFailures(id, message, firstAnomaly, restOfAnomalies) with Product with Serializable

--- a/core/src/main/scala/busymachines/core/anomaly.scala
+++ b/core/src/main/scala/busymachines/core/anomaly.scala
@@ -53,17 +53,29 @@ trait Anomaly extends Product with Serializable {
   * - [[busymachines.core.MeaningfulAnomalies.InvalidInput]]
   *   - range: 400-499; e.g. pone_400, ptwo_476, pthree_499
   */
-trait AnomalyID extends Product with Serializable {
+trait AnomalyID extends Product with Serializable with Equals {
   def name: String
+
+  final override def canEqual(that: Any): Boolean = that.isInstanceOf[AnomalyID]
+
+  final override def equals(obj: Any): Boolean = canEqual(obj) && this.hashCode() == obj.hashCode()
+
+  final override def hashCode(): Int = name.hashCode * 13
+
+  override def toString: String = name
 }
 
 object AnomalyID {
   def apply(id: String): AnomalyID = AnomalyIDUnderlying(id)
 }
 
+private[core] case object DefaultAnomalyID extends AnomalyID {
+  override val name: String = "DA_0"
+}
 private[core] final case class AnomalyIDUnderlying(override val name: String) extends AnomalyID
 
-object Anomaly {
+object Anomaly extends AnomalyConstructors[Anomaly] {
+  private[core] val Anomaly: String = "Anomaly"
 
   type Param = StringOrSeqString
 
@@ -81,21 +93,33 @@ object Anomaly {
     def empty: Parameters = Map.empty[String, Param]
   }
 
-  @scala.deprecated("WIP", "now")
-  def apply(
-    id:         AnomalyID,
-    message:    String,
-    parameters: Parameters = Anomaly.Parameters.empty
-  ): Anomaly = {
-    AnomalyImpl(id, message, parameters)
-  }
+  override def apply(id: AnomalyID): Anomaly = AnomalyImpl(id = id)
+
+  override def apply(message: String): Anomaly = AnomalyImpl(message = message)
+
+  override def apply(parameters: Parameters): Anomaly = AnomalyImpl(parameters = parameters)
+
+  override def apply(id: AnomalyID, message: String): Anomaly =
+    AnomalyImpl(id = id, message = message)
+
+  override def apply(id: AnomalyID, parameters: Parameters): Anomaly =
+    AnomalyImpl(id = id, parameters = parameters)
+
+  override def apply(message: String, parameters: Parameters): Anomaly =
+    AnomalyImpl(message = message, parameters = parameters)
+
+  override def apply(id: AnomalyID, message: String, parameters: Parameters): Anomaly =
+    AnomalyImpl(id = id, message = message, parameters = parameters)
+
+  override def apply(a: Anomaly): Anomaly =
+    AnomalyImpl(id = a.id, message = a.message, parameters = a.parameters)
+
 }
 
-@scala.deprecated("WIP", "now")
 private[core] final case class AnomalyImpl(
-  override val id:         AnomalyID,
-  override val message:    String,
-  override val parameters: AnomalyParameters
+  override val id:         AnomalyID         = DefaultAnomalyID,
+  override val message:    String            = Anomaly.Anomaly,
+  override val parameters: AnomalyParameters = AnomalyParameters.empty
 ) extends Anomaly {
 
   override def asThrowable: Throwable =
@@ -125,8 +149,59 @@ abstract class AnomalousFailure(
   final override def asThrowable: Throwable = this
 }
 
+private[core] case object AnomalousFailureID extends AnomalyID {
+  override val name: String = "AF_0"
+}
+
+object AnomalousFailure extends FailureConstructors[AnomalousFailure] {
+  private[core] val AnomalousFailure = "Anomalous Failure"
+  import busymachines.core.Anomaly.Parameters
+
+  override def apply(causedBy: Throwable): AnomalousFailure = AnomalousFailureImpl(causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID, message: String, causedBy: Throwable): AnomalousFailure =
+    AnomalousFailureImpl(id = id, message = message, causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID, parameters: Parameters, causedBy: Throwable): AnomalousFailure =
+    AnomalousFailureImpl(id = id, parameters = parameters, causedBy = Option(causedBy))
+
+  override def apply(message: String, parameters: Parameters, causedBy: Throwable): AnomalousFailure =
+    AnomalousFailureImpl(message = message, parameters = parameters, causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID, message: String, parameters: Parameters, causedBy: Throwable): AnomalousFailure =
+    AnomalousFailureImpl(id = id, message = message, parameters = parameters, causedBy = Option(causedBy))
+
+  override def apply(a: Anomaly, causedBy: Throwable): AnomalousFailure =
+    AnomalousFailureImpl(id = a.id, message = a.message, parameters = a.parameters, causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID): AnomalousFailure =
+    AnomalousFailureImpl(id = id)
+
+  override def apply(message: String): AnomalousFailure =
+    AnomalousFailureImpl(message = message)
+
+  override def apply(parameters: Parameters): AnomalousFailure =
+    AnomalousFailureImpl(parameters = parameters)
+
+  override def apply(id: AnomalyID, message: String): AnomalousFailure =
+    AnomalousFailureImpl(id = id, message = message)
+
+  override def apply(id: AnomalyID, parameters: Parameters): AnomalousFailure =
+    AnomalousFailureImpl(id = id, parameters = parameters)
+
+  override def apply(message: String, parameters: Parameters): AnomalousFailure =
+    AnomalousFailureImpl(message = message, parameters = parameters)
+
+  override def apply(id: AnomalyID, message: String, parameters: Parameters): AnomalousFailure =
+    AnomalousFailureImpl(id = id, message = message, parameters = parameters)
+
+  override def apply(a: Anomaly): AnomalousFailure =
+    AnomalousFailureImpl(id = a.id, message = a.message, parameters = a.parameters)
+}
+
 private[core] final case class AnomalousFailureImpl(
-  override val id:         AnomalyID,
-  override val message:    String,
-  override val parameters: Anomaly.Parameters
-) extends AnomalousFailure(message)
+  override val id:         AnomalyID          = AnomalousFailureID,
+  override val message:    String             = AnomalousFailure.AnomalousFailure,
+  override val parameters: Anomaly.Parameters = Anomaly.Parameters.empty,
+  causedBy:                Option[Throwable]  = None
+) extends AnomalousFailure(message, causedBy)

--- a/core/src/main/scala/busymachines/core/anomaly.scala
+++ b/core/src/main/scala/busymachines/core/anomaly.scala
@@ -117,8 +117,8 @@ object Anomaly extends AnomalyConstructors[Anomaly] {
 }
 
 private[core] final case class AnomalyImpl(
-  override val id:         AnomalyID         = DefaultAnomalyID,
-  override val message:    String            = Anomaly.Anomaly,
+  override val id:         AnomalyID          = DefaultAnomalyID,
+  override val message:    String             = Anomaly.Anomaly,
   override val parameters: Anomaly.Parameters = Anomaly.Parameters.empty
 ) extends Anomaly {
 
@@ -197,6 +197,9 @@ object AnomalousFailure extends FailureConstructors[AnomalousFailure] {
 
   override def apply(a: Anomaly): AnomalousFailure =
     AnomalousFailureImpl(id = a.id, message = a.message, parameters = a.parameters)
+
+  override def apply(message: String, causedBy: Throwable): AnomalousFailure =
+    AnomalousFailureImpl(message = message, causedBy = Option(causedBy))
 }
 
 private[core] final case class AnomalousFailureImpl(

--- a/core/src/main/scala/busymachines/core/anomaly.scala
+++ b/core/src/main/scala/busymachines/core/anomaly.scala
@@ -34,6 +34,25 @@ trait Anomaly extends Product with Serializable {
   def asThrowable: Throwable
 }
 
+/**
+  * Some suggested naming conventions are put here so that they're easily accessible.
+  * These can also be found in the scaladoc of [[busymachines.core.MeaningfulAnomalies]]
+  *
+  * - [[busymachines.core.MeaningfulAnomalies.NotFound]]
+  *   - range: 000-099; e.g. pone_001, ptwo_076, pthree_099
+  *
+  * - [[busymachines.core.MeaningfulAnomalies.Unauthorized]]
+  *   - range: 100-199; e.g. pone_100, ptwo_176, pthree_199
+  *
+  * - [[busymachines.core.MeaningfulAnomalies.Forbidden]]
+  *   - range: 200-299; e.g. pone_200, ptwo_276, pthree_299
+  *
+  * - [[busymachines.core.MeaningfulAnomalies.Denied]]
+  *   - range: 300-399; e.g. pone_300, ptwo_376, pthree_399
+  *
+  * - [[busymachines.core.MeaningfulAnomalies.InvalidInput]]
+  *   - range: 400-499; e.g. pone_400, ptwo_476, pthree_499
+  */
 trait AnomalyID extends Product with Serializable {
   def name: String
 }

--- a/core/src/main/scala/busymachines/core/anomaly.scala
+++ b/core/src/main/scala/busymachines/core/anomaly.scala
@@ -46,7 +46,7 @@ private[core] final case class AnomalyIDUnderlying(override val name: String) ex
 
 object Anomaly {
 
-  type PValue = StringOrSeqString
+  type Param = StringOrSeqString
 
   object ParamValue {
     def apply(s: String) = StringWrapper(s)
@@ -54,12 +54,12 @@ object Anomaly {
     def apply(ses: immutable.Seq[String]) = SeqStringWrapper(ses)
   }
 
-  type Parameters = Map[String, PValue]
+  type Parameters = Map[String, Param]
 
   object Parameters {
-    def apply(ps: (String, PValue)*): Parameters = Map.apply(ps: _*)
+    def apply(ps: (String, Param)*): Parameters = Map.apply(ps: _*)
 
-    def empty: Parameters = Map.empty[String, PValue]
+    def empty: Parameters = Map.empty[String, Param]
   }
 
   @scala.deprecated("WIP", "now")
@@ -76,7 +76,7 @@ object Anomaly {
 private[core] final case class AnomalyImpl(
   override val id:         AnomalyID,
   override val message:    String,
-  override val parameters: Anomaly.Parameters
+  override val parameters: AnomalyParameters
 ) extends Anomaly {
 
   override def asThrowable: Throwable =

--- a/core/src/main/scala/busymachines/core/anomaly.scala
+++ b/core/src/main/scala/busymachines/core/anomaly.scala
@@ -1,0 +1,113 @@
+package busymachines.core
+
+import scala.collection.immutable
+
+/**
+  * @author Lorand Szakacs, lsz@lorandszakacs.com, lorand.szakacs@busymachines.com
+  * @since 26 Dec 2017
+  *
+  */
+trait Anomaly extends Product with Serializable {
+  def id: AnomalyID
+
+  def message: String
+
+  def parameters: Anomaly.Parameters = Anomaly.Parameters.empty
+
+  /**
+    * * In case that "this" is already a Throwable, e.g. it was used in the
+    * exception throwing manner to begin with then this is easy.
+    *
+    * Otherwise, if it was used in the monadic propagation on the lhs of an Either
+    * then this is a thorny issue. This method is required for interop with stuff like
+    * Future, Try, Task, etc., stuff that encapsulates a Throwable.
+    *
+    * They lose specific type information about the exception anyway,
+    * so there is no point in preserving it in the return type of this method.
+    *
+    * Therefore, this method should guarantee that the runtime properties of the new
+    * Throwable match those of "this". i.e.
+    *   - it should have the same [[busymachines.core.MeaningfulAnomalies]] marker at runtime, if any
+    *   - and ensure that all properties id, message, parameters, get propagated properly
+    *
+    */
+  def asThrowable: Throwable
+}
+
+trait AnomalyID extends Product with Serializable {
+  def name: String
+}
+
+object AnomalyID {
+  def apply(id: String): AnomalyID = AnomalyIDUnderlying(id)
+}
+
+private[core] final case class AnomalyIDUnderlying(override val name: String) extends AnomalyID
+
+object Anomaly {
+
+  type PValue = StringOrSeqString
+
+  object ParamValue {
+    def apply(s: String) = StringWrapper(s)
+
+    def apply(ses: immutable.Seq[String]) = SeqStringWrapper(ses)
+  }
+
+  type Parameters = Map[String, PValue]
+
+  object Parameters {
+    def apply(ps: (String, PValue)*): Parameters = Map.apply(ps: _*)
+
+    def empty: Parameters = Map.empty[String, PValue]
+  }
+
+  @scala.deprecated("WIP", "now")
+  def apply(
+    id:         AnomalyID,
+    message:    String,
+    parameters: Parameters = Anomaly.Parameters.empty
+  ): Anomaly = {
+    AnomalyImpl(id, message, parameters)
+  }
+}
+
+@scala.deprecated("WIP", "now")
+private[core] final case class AnomalyImpl(
+  override val id:         AnomalyID,
+  override val message:    String,
+  override val parameters: Anomaly.Parameters
+) extends Anomaly {
+
+  override def asThrowable: Throwable =
+    AnomalousFailureImpl(id, message, parameters)
+}
+
+/**
+  * This is a hack until dotty (scala 3.0) comes along with union types.
+  * Until then, boiler plate freedom is given by the implicit
+  * conversions found in the package object
+  */
+sealed trait StringOrSeqString extends Product with Serializable
+
+final case class StringWrapper private (s: String) extends StringOrSeqString
+
+final case class SeqStringWrapper private (ses: immutable.Seq[String]) extends StringOrSeqString
+
+/**
+  * The moment an [[busymachines.core.Anomaly]] inherits
+  * from the impure works of [[java.lang.Exception]] it is
+  * referred to as a "Failure"
+  */
+abstract class AnomalousFailure(
+  override val message: String,
+  causedBy:             Option[Throwable] = None
+) extends Exception(message, causedBy.orNull) with Anomaly {
+  final override def asThrowable: Throwable = this
+}
+
+private[core] final case class AnomalousFailureImpl(
+  override val id:         AnomalyID,
+  override val message:    String,
+  override val parameters: Anomaly.Parameters
+) extends AnomalousFailure(message)

--- a/core/src/main/scala/busymachines/core/anomaly.scala
+++ b/core/src/main/scala/busymachines/core/anomaly.scala
@@ -77,7 +77,7 @@ private[core] final case class AnomalyIDUnderlying(override val name: String) ex
 object Anomaly extends AnomalyConstructors[Anomaly] {
   private[core] val Anomaly: String = "Anomaly"
 
-  type Param = StringOrSeqString
+  type Parameter = StringOrSeqString
 
   object ParamValue {
     def apply(s: String) = StringWrapper(s)
@@ -85,12 +85,12 @@ object Anomaly extends AnomalyConstructors[Anomaly] {
     def apply(ses: immutable.Seq[String]) = SeqStringWrapper(ses)
   }
 
-  type Parameters = Map[String, Param]
+  type Parameters = Map[String, Parameter]
 
   object Parameters {
-    def apply(ps: (String, Param)*): Parameters = Map.apply(ps: _*)
+    def apply(ps: (String, Parameter)*): Parameters = Map.apply(ps: _*)
 
-    def empty: Parameters = Map.empty[String, Param]
+    def empty: Parameters = Map.empty[String, Parameter]
   }
 
   override def apply(id: AnomalyID): Anomaly = AnomalyImpl(id = id)
@@ -119,7 +119,7 @@ object Anomaly extends AnomalyConstructors[Anomaly] {
 private[core] final case class AnomalyImpl(
   override val id:         AnomalyID         = DefaultAnomalyID,
   override val message:    String            = Anomaly.Anomaly,
-  override val parameters: AnomalyParameters = AnomalyParameters.empty
+  override val parameters: Anomaly.Parameters = Anomaly.Parameters.empty
 ) extends Anomaly {
 
   override def asThrowable: Throwable =

--- a/core/src/main/scala/busymachines/core/anomaly.scala
+++ b/core/src/main/scala/busymachines/core/anomaly.scala
@@ -78,19 +78,24 @@ object Anomaly extends AnomalyConstructors[Anomaly] {
   private[core] val Anomaly: String = "Anomaly"
 
   type Parameter = StringOrSeqString
-
-  object ParamValue {
-    def apply(s: String) = StringWrapper(s)
-
-    def apply(ses: immutable.Seq[String]) = SeqStringWrapper(ses)
-  }
+  def Parameter(s:   String):                StringOrSeqString = StringWrapper(s)
+  def Parameter(ses: immutable.Seq[String]): StringOrSeqString = SeqStringWrapper(ses)
 
   type Parameters = Map[String, Parameter]
 
-  object Parameters {
-    def apply(ps: (String, Parameter)*): Parameters = Map.apply(ps: _*)
+  /**
+    * the reason why this type signature does not return Parameters is a pragmatical one,
+    * where intellij, does not infer it correctly in the IDE, and yields a false negative.
+    *
+    * As far as the client code is concerned this is the same, and scalac properly
+    * compiles both versions, so we'll keep the one which causes the least misery.
+    *
+    * Once intellij fixes this (need to look for issue) we can have cleaner code here
+    */
+  def Parameters(ps: (String, Parameter)*): Map[String, StringOrSeqString] = Map.apply(ps: _*)
 
-    def empty: Parameters = Map.empty[String, Parameter]
+  object Parameters {
+    def empty: Map[String, StringOrSeqString] = Map.empty[String, Parameter]
   }
 
   override def apply(id: AnomalyID): Anomaly = AnomalyImpl(id = id)

--- a/core/src/main/scala/busymachines/core/catastrophe.scala
+++ b/core/src/main/scala/busymachines/core/catastrophe.scala
@@ -1,0 +1,157 @@
+package busymachines.core
+import busymachines.core.Anomaly.Parameters
+
+/**
+  * @author Lorand Szakacs, lsz@lorandszakacs.com, lorand.szakacs@busymachines.com
+  * @since 26 Dec 2017
+  *
+  */
+trait Catastrophe extends Anomaly with Product with Serializable
+
+/**
+  * [[java.lang.Error]] is a reasonable choice for a super-class.
+  * It's not caught by NonFatal(_)pattern matches. Which means that
+  * we can properly propagate "irrecoverable errors" one a per "request"
+  * basis and at the same time not crash our application into oblivion.
+  */
+abstract class CatastrophicError(
+  override val message: String,
+  causedBy:             Option[Throwable] = None
+) extends Error(message, causedBy.orNull) with Catastrophe with Product with Serializable {
+  final override def asThrowable: Throwable = this
+}
+
+object CatastrophicError extends CatastrophicErrorConstructors[CatastrophicError] {
+  private[core] val `Catastrophic Error` = "Catastrophic Error"
+
+  override def apply(causedBy: Throwable): CatastrophicError = CatastrophicErrorImpl(causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID, message: String, causedBy: Throwable): CatastrophicError =
+    CatastrophicErrorImpl(id = id, message = message, causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID, parameters: Parameters, causedBy: Throwable): CatastrophicError =
+    CatastrophicErrorImpl(id = id, parameters = parameters, causedBy = Option(causedBy))
+
+  override def apply(message: String, parameters: Parameters, causedBy: Throwable): CatastrophicError =
+    CatastrophicErrorImpl(message = message, parameters = parameters, causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID, message: String, parameters: Parameters, causedBy: Throwable): CatastrophicError =
+    CatastrophicErrorImpl(id = id, message = message, parameters = parameters, causedBy = Option(causedBy))
+
+  override def apply(a: Anomaly, causedBy: Throwable): CatastrophicError =
+    CatastrophicErrorImpl(id = a.id, message = a.message, parameters = a.parameters, causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID): CatastrophicError =
+    CatastrophicErrorImpl(id = id)
+
+  override def apply(message: String): CatastrophicError =
+    CatastrophicErrorImpl(message = message)
+
+  override def apply(parameters: Parameters): CatastrophicError =
+    CatastrophicErrorImpl(parameters = parameters)
+
+  override def apply(id: AnomalyID, message: String): CatastrophicError =
+    CatastrophicErrorImpl(id = id, message = message)
+
+  override def apply(id: AnomalyID, parameters: Parameters): CatastrophicError =
+    CatastrophicErrorImpl(id = id, parameters = parameters)
+
+  override def apply(message: String, parameters: Parameters): CatastrophicError =
+    CatastrophicErrorImpl(message = message, parameters = parameters)
+
+  override def apply(id: AnomalyID, message: String, parameters: Parameters): CatastrophicError =
+    CatastrophicErrorImpl(id = id, message = message, parameters = parameters)
+
+  override def apply(a: Anomaly): CatastrophicError =
+    CatastrophicErrorImpl(id = a.id, message = a.message, parameters = a.parameters, causedBy = Option(a.asThrowable))
+}
+
+private[core] case object CatastrophicErrorID extends AnomalyID with Product with Serializable {
+  override val name: String = "CE_0"
+}
+
+private[core] final case class CatastrophicErrorImpl(
+  override val id:         AnomalyID          = CatastrophicErrorID,
+  override val message:    String             = CatastrophicError.`Catastrophic Error`,
+  override val parameters: Anomaly.Parameters = AnomalyParameters.empty,
+  causedBy:                Option[Throwable]  = None
+) extends CatastrophicError(message, causedBy = causedBy)
+
+//=============================================================================
+//=============================================================================
+//=============================================================================
+
+trait InconsistentStateCatastrophe extends Catastrophe
+
+private[core] case object InconsistentStateCatastropheID extends AnomalyID with Product with Serializable {
+  override val name: String = "IS_0"
+}
+
+object InconsistentStateError extends CatastrophicErrorConstructors[InconsistentStateError] {
+  private[core] val InconsistentStateError: String = "Inconsistent State Error"
+
+  override def apply(causedBy: Throwable): InconsistentStateError =
+    InconsistentStateErrorImpl(causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID, message: String, causedBy: Throwable): InconsistentStateError =
+    InconsistentStateErrorImpl(id = id, message = message, causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID, parameters: Parameters, causedBy: Throwable): InconsistentStateError =
+    InconsistentStateErrorImpl(id = id, parameters = parameters, causedBy = Option(causedBy))
+
+  override def apply(message: String, parameters: Parameters, causedBy: Throwable): InconsistentStateError =
+    InconsistentStateErrorImpl(message = message, parameters = parameters, causedBy = Option(causedBy))
+
+  override def apply(
+    id:         AnomalyID,
+    message:    String,
+    parameters: Parameters,
+    causedBy:   Throwable
+  ): InconsistentStateError =
+    InconsistentStateErrorImpl(id = id, message = message, parameters = parameters, causedBy = Option(causedBy))
+
+  override def apply(a: Anomaly, causedBy: Throwable): InconsistentStateError =
+    InconsistentStateErrorImpl(id = a.id, message = a.message, parameters = a.parameters, causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID): InconsistentStateError =
+    InconsistentStateErrorImpl(id = id)
+
+  override def apply(message: String): InconsistentStateError =
+    InconsistentStateErrorImpl(message = message)
+
+  override def apply(parameters: Parameters): InconsistentStateError =
+    InconsistentStateErrorImpl(parameters = parameters)
+
+  override def apply(id: AnomalyID, message: String): InconsistentStateError =
+    InconsistentStateErrorImpl(id = id, message = message)
+
+  override def apply(id: AnomalyID, parameters: Parameters): InconsistentStateError =
+    InconsistentStateErrorImpl(id = id, parameters = parameters)
+
+  override def apply(message: String, parameters: Parameters): InconsistentStateError =
+    InconsistentStateErrorImpl(message = message, parameters = parameters)
+
+  override def apply(id: AnomalyID, message: String, parameters: Parameters): InconsistentStateError =
+    InconsistentStateErrorImpl(id = id, message = message, parameters = parameters)
+
+  override def apply(a: Anomaly): InconsistentStateError =
+    InconsistentStateErrorImpl(
+      id         = a.id,
+      message    = a.message,
+      parameters = a.parameters,
+      causedBy   = Option(a.asThrowable)
+    )
+
+}
+
+abstract class InconsistentStateError(
+  override val message: String,
+  causedBy:             Option[Throwable] = None
+) extends CatastrophicError(message, causedBy) with InconsistentStateCatastrophe with Product with Serializable
+
+private[core] final case class InconsistentStateErrorImpl(
+  override val id:         AnomalyID          = InconsistentStateCatastropheID,
+  override val message:    String             = InconsistentStateError.InconsistentStateError,
+  override val parameters: Anomaly.Parameters = AnomalyParameters.empty,
+  causedBy:                Option[Throwable]  = None
+) extends InconsistentStateError(message, causedBy = causedBy)

--- a/core/src/main/scala/busymachines/core/catastrophe.scala
+++ b/core/src/main/scala/busymachines/core/catastrophe.scala
@@ -73,7 +73,7 @@ private[core] case object CatastrophicErrorID extends AnomalyID with Product wit
 private[core] final case class CatastrophicErrorImpl(
   override val id:         AnomalyID          = CatastrophicErrorID,
   override val message:    String             = CatastrophicError.`Catastrophic Error`,
-  override val parameters: Anomaly.Parameters = AnomalyParameters.empty,
+  override val parameters: Anomaly.Parameters = Anomaly.Parameters.empty,
   causedBy:                Option[Throwable]  = None
 ) extends CatastrophicError(message, causedBy = causedBy)
 
@@ -152,6 +152,6 @@ abstract class InconsistentStateError(
 private[core] final case class InconsistentStateErrorImpl(
   override val id:         AnomalyID          = InconsistentStateCatastropheID,
   override val message:    String             = InconsistentStateError.InconsistentStateError,
-  override val parameters: Anomaly.Parameters = AnomalyParameters.empty,
+  override val parameters: Anomaly.Parameters = Anomaly.Parameters.empty,
   causedBy:                Option[Throwable]  = None
 ) extends InconsistentStateError(message, causedBy = causedBy)

--- a/core/src/main/scala/busymachines/core/catastrophe.scala
+++ b/core/src/main/scala/busymachines/core/catastrophe.scala
@@ -64,6 +64,9 @@ object CatastrophicError extends CatastrophicErrorConstructors[CatastrophicError
 
   override def apply(a: Anomaly): CatastrophicError =
     CatastrophicErrorImpl(id = a.id, message = a.message, parameters = a.parameters, causedBy = Option(a.asThrowable))
+
+  override def apply(message: String, causedBy: Throwable): CatastrophicError =
+    CatastrophicErrorImpl(message = message, causedBy = Option(causedBy))
 }
 
 private[core] case object CatastrophicErrorID extends AnomalyID with Product with Serializable {
@@ -142,6 +145,8 @@ object InconsistentStateError extends CatastrophicErrorConstructors[Inconsistent
       causedBy   = Option(a.asThrowable)
     )
 
+  override def apply(message: String, causedBy: Throwable): InconsistentStateError =
+    InconsistentStateErrorImpl(message = message, causedBy = Option(causedBy))
 }
 
 abstract class InconsistentStateError(

--- a/core/src/main/scala/busymachines/core/conflictAnomaly.scala
+++ b/core/src/main/scala/busymachines/core/conflictAnomaly.scala
@@ -1,0 +1,104 @@
+package busymachines.core
+
+import busymachines.core.Anomaly.Parameters
+
+/**
+  *
+  * @author Lorand Szakacs, lsz@lorandszakacs.com, lorand.szakacs@busymachines.com
+  * @since 26 Dec 2017
+  *
+  */
+trait ConflictAnomaly extends Anomaly with MeaningfulAnomalies.Conflict with Product with Serializable
+
+object ConflictAnomaly extends AnomalyConstructors[ConflictAnomaly] {
+  override def apply(id: AnomalyID): ConflictAnomaly = ConflictAnomalyImpl(id = id)
+
+  override def apply(message: String): ConflictAnomaly = ConflictAnomalyImpl(message = message)
+
+  override def apply(parameters: Parameters): ConflictAnomaly = ConflictAnomalyImpl(parameters = parameters)
+
+  override def apply(id: AnomalyID, message: String): ConflictAnomaly =
+    ConflictAnomalyImpl(id = id, message = message)
+
+  override def apply(id: AnomalyID, parameters: Parameters): ConflictAnomaly =
+    ConflictAnomalyImpl(id = id, parameters = parameters)
+
+  override def apply(message: String, parameters: Parameters): ConflictAnomaly =
+    ConflictAnomalyImpl(message = message, parameters = parameters)
+
+  override def apply(id: AnomalyID, message: String, parameters: Parameters): ConflictAnomaly =
+    ConflictAnomalyImpl(id = id, message = message, parameters = parameters)
+
+  override def apply(a: Anomaly): ConflictAnomaly =
+    ConflictAnomalyImpl(id = a.id, message = a.message, parameters = a.parameters)
+}
+
+private[core] final case class ConflictAnomalyImpl(
+  override val id:         AnomalyID  = ConflictAnomalyID,
+  override val message:    String     = MeaningfulAnomalies.`Conflict`,
+  override val parameters: Parameters = Parameters.empty
+) extends ConflictAnomaly with Product with Serializable {
+
+  override def asThrowable: Throwable = ConflictFailureImpl(id, message, parameters)
+}
+
+//=============================================================================
+//=============================================================================
+//=============================================================================
+
+abstract class ConflictFailure(
+  override val message: String,
+  causedBy:             Option[Throwable] = None,
+) extends AnomalousFailure(message, causedBy) with ConflictAnomaly with Product with Serializable {
+  override def id: AnomalyID = ConflictAnomalyID
+}
+
+object ConflictFailure extends FailureConstructors[ConflictFailure] {
+  override def apply(causedBy: Throwable): ConflictFailure = ConflictFailureImpl(causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID, message: String, causedBy: Throwable): ConflictFailure =
+    ConflictFailureImpl(id = id, message = message, causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID, parameters: Parameters, causedBy: Throwable): ConflictFailure =
+    ConflictFailureImpl(id = id, parameters = parameters, causedBy = Option(causedBy))
+
+  override def apply(message: String, parameters: Parameters, causedBy: Throwable): ConflictFailure =
+    ConflictFailureImpl(message = message, parameters = parameters, causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID, message: String, parameters: Parameters, causedBy: Throwable): ConflictFailure =
+    ConflictFailureImpl(id = id, message = message, parameters = parameters, causedBy = Option(causedBy))
+
+  override def apply(a: Anomaly, causedBy: Throwable): ConflictFailure =
+    ConflictFailureImpl(id = a.id, message = a.message, parameters = a.parameters, causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID): ConflictFailure =
+    ConflictFailureImpl(id = id)
+
+  override def apply(message: String): ConflictFailure =
+    ConflictFailureImpl(message = message)
+
+  override def apply(parameters: Parameters): ConflictFailure =
+    ConflictFailureImpl(parameters = parameters)
+
+  override def apply(id: AnomalyID, message: String): ConflictFailure =
+    ConflictFailureImpl(id = id, message = message)
+
+  override def apply(id: AnomalyID, parameters: Parameters): ConflictFailure =
+    ConflictFailureImpl(id = id, parameters = parameters)
+
+  override def apply(message: String, parameters: Parameters): ConflictFailure =
+    ConflictFailureImpl(message = message, parameters = parameters)
+
+  override def apply(id: AnomalyID, message: String, parameters: Parameters): ConflictFailure =
+    ConflictFailureImpl(id = id, message = message, parameters = parameters)
+
+  override def apply(a: Anomaly): ConflictFailure =
+    ConflictFailureImpl(id = a.id, message = a.message, parameters = a.parameters)
+}
+
+private[core] final case class ConflictFailureImpl(
+  override val id:         AnomalyID         = ConflictAnomalyID,
+  override val message:    String            = MeaningfulAnomalies.`Conflict`,
+  override val parameters: Parameters        = Parameters.empty,
+  causedBy:                Option[Throwable] = None,
+) extends ConflictFailure(message, causedBy) with Product with Serializable

--- a/core/src/main/scala/busymachines/core/conflictAnomaly.scala
+++ b/core/src/main/scala/busymachines/core/conflictAnomaly.scala
@@ -94,6 +94,9 @@ object ConflictFailure extends FailureConstructors[ConflictFailure] {
 
   override def apply(a: Anomaly): ConflictFailure =
     ConflictFailureImpl(id = a.id, message = a.message, parameters = a.parameters)
+
+  override def apply(message: String, causedBy: Throwable): ConflictFailure =
+    ConflictFailureImpl(message = message, causedBy = Option(causedBy))
 }
 
 private[core] final case class ConflictFailureImpl(

--- a/core/src/main/scala/busymachines/core/conflictAnomaly.scala
+++ b/core/src/main/scala/busymachines/core/conflictAnomaly.scala
@@ -53,7 +53,9 @@ abstract class ConflictFailure(
   override def id: AnomalyID = ConflictAnomalyID
 }
 
-object ConflictFailure extends FailureConstructors[ConflictFailure] {
+object ConflictFailure
+    extends ConflictFailure(MeaningfulAnomalies.`Conflict`, None) with SingletonAnomalyProduct
+    with FailureConstructors[ConflictFailure] {
   override def apply(causedBy: Throwable): ConflictFailure = ConflictFailureImpl(causedBy = Option(causedBy))
 
   override def apply(id: AnomalyID, message: String, causedBy: Throwable): ConflictFailure =

--- a/core/src/main/scala/busymachines/core/deniedAnomaly.scala
+++ b/core/src/main/scala/busymachines/core/deniedAnomaly.scala
@@ -1,0 +1,104 @@
+package busymachines.core
+
+import busymachines.core.Anomaly.Parameters
+
+/**
+  *
+  * @author Lorand Szakacs, lsz@lorandszakacs.com, lorand.szakacs@busymachines.com
+  * @since 26 Dec 2017
+  *
+  */
+trait DeniedAnomaly extends Anomaly with MeaningfulAnomalies.Denied with Product with Serializable
+
+object DeniedAnomaly extends AnomalyConstructors[DeniedAnomaly] {
+  override def apply(id: AnomalyID): DeniedAnomaly = DeniedAnomalyImpl(id = id)
+
+  override def apply(message: String): DeniedAnomaly = DeniedAnomalyImpl(message = message)
+
+  override def apply(parameters: Parameters): DeniedAnomaly = DeniedAnomalyImpl(parameters = parameters)
+
+  override def apply(id: AnomalyID, message: String): DeniedAnomaly =
+    DeniedAnomalyImpl(id = id, message = message)
+
+  override def apply(id: AnomalyID, parameters: Parameters): DeniedAnomaly =
+    DeniedAnomalyImpl(id = id, parameters = parameters)
+
+  override def apply(message: String, parameters: Parameters): DeniedAnomaly =
+    DeniedAnomalyImpl(message = message, parameters = parameters)
+
+  override def apply(id: AnomalyID, message: String, parameters: Parameters): DeniedAnomaly =
+    DeniedAnomalyImpl(id = id, message = message, parameters = parameters)
+
+  override def apply(a: Anomaly): DeniedAnomaly =
+    DeniedAnomalyImpl(id = a.id, message = a.message, parameters = a.parameters)
+}
+
+private[core] final case class DeniedAnomalyImpl(
+  override val id:         AnomalyID  = DeniedAnomalyID,
+  override val message:    String     = MeaningfulAnomalies.`Denied`,
+  override val parameters: Parameters = Parameters.empty
+) extends DeniedAnomaly {
+
+  override def asThrowable: Throwable = DeniedFailureImpl(id, message, parameters)
+}
+
+//=============================================================================
+//=============================================================================
+//=============================================================================
+
+abstract class DeniedFailure(
+  override val message: String,
+  causedBy:             Option[Throwable] = None,
+) extends AnomalousFailure(message, causedBy) with DeniedAnomaly {
+  override def id: AnomalyID = DeniedAnomalyID
+}
+
+object DeniedFailure extends FailureConstructors[DeniedFailure] {
+  override def apply(causedBy: Throwable): DeniedFailure = DeniedFailureImpl(causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID, message: String, causedBy: Throwable): DeniedFailure =
+    DeniedFailureImpl(id = id, message = message, causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID, parameters: Parameters, causedBy: Throwable): DeniedFailure =
+    DeniedFailureImpl(id = id, parameters = parameters, causedBy = Option(causedBy))
+
+  override def apply(message: String, parameters: Parameters, causedBy: Throwable): DeniedFailure =
+    DeniedFailureImpl(message = message, parameters = parameters, causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID, message: String, parameters: Parameters, causedBy: Throwable): DeniedFailure =
+    DeniedFailureImpl(id = id, message = message, parameters = parameters, causedBy = Option(causedBy))
+
+  override def apply(a: Anomaly, causedBy: Throwable): DeniedFailure =
+    DeniedFailureImpl(id = a.id, message = a.message, parameters = a.parameters, causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID): DeniedFailure =
+    DeniedFailureImpl(id = id)
+
+  override def apply(message: String): DeniedFailure =
+    DeniedFailureImpl(message = message)
+
+  override def apply(parameters: Parameters): DeniedFailure =
+    DeniedFailureImpl(parameters = parameters)
+
+  override def apply(id: AnomalyID, message: String): DeniedFailure =
+    DeniedFailureImpl(id = id, message = message)
+
+  override def apply(id: AnomalyID, parameters: Parameters): DeniedFailure =
+    DeniedFailureImpl(id = id, parameters = parameters)
+
+  override def apply(message: String, parameters: Parameters): DeniedFailure =
+    DeniedFailureImpl(message = message, parameters = parameters)
+
+  override def apply(id: AnomalyID, message: String, parameters: Parameters): DeniedFailure =
+    DeniedFailureImpl(id = id, message = message, parameters = parameters)
+
+  override def apply(a: Anomaly): DeniedFailure =
+    DeniedFailureImpl(id = a.id, message = a.message, parameters = a.parameters)
+}
+
+private[core] final case class DeniedFailureImpl(
+  override val id:         AnomalyID         = DeniedAnomalyID,
+  override val message:    String            = MeaningfulAnomalies.`Denied`,
+  override val parameters: Parameters        = Parameters.empty,
+  causedBy:                Option[Throwable] = None,
+) extends DeniedFailure(message, causedBy)

--- a/core/src/main/scala/busymachines/core/deniedAnomaly.scala
+++ b/core/src/main/scala/busymachines/core/deniedAnomaly.scala
@@ -37,7 +37,7 @@ private[core] final case class DeniedAnomalyImpl(
   override val id:         AnomalyID  = DeniedAnomalyID,
   override val message:    String     = MeaningfulAnomalies.`Denied`,
   override val parameters: Parameters = Parameters.empty
-) extends DeniedAnomaly {
+) extends DeniedAnomaly with Product with Serializable {
 
   override def asThrowable: Throwable = DeniedFailureImpl(id, message, parameters)
 }
@@ -49,7 +49,7 @@ private[core] final case class DeniedAnomalyImpl(
 abstract class DeniedFailure(
   override val message: String,
   causedBy:             Option[Throwable] = None,
-) extends AnomalousFailure(message, causedBy) with DeniedAnomaly {
+) extends AnomalousFailure(message, causedBy) with DeniedAnomaly with Product with Serializable {
   override def id: AnomalyID = DeniedAnomalyID
 }
 
@@ -101,4 +101,4 @@ private[core] final case class DeniedFailureImpl(
   override val message:    String            = MeaningfulAnomalies.`Denied`,
   override val parameters: Parameters        = Parameters.empty,
   causedBy:                Option[Throwable] = None,
-) extends DeniedFailure(message, causedBy)
+) extends DeniedFailure(message, causedBy) with Product with Serializable

--- a/core/src/main/scala/busymachines/core/deniedAnomaly.scala
+++ b/core/src/main/scala/busymachines/core/deniedAnomaly.scala
@@ -53,7 +53,9 @@ abstract class DeniedFailure(
   override def id: AnomalyID = DeniedAnomalyID
 }
 
-object DeniedFailure extends FailureConstructors[DeniedFailure] {
+object DeniedFailure
+    extends DeniedFailure(MeaningfulAnomalies.`Denied`, None) with SingletonAnomalyProduct
+    with FailureConstructors[DeniedFailure] {
   override def apply(causedBy: Throwable): DeniedFailure = DeniedFailureImpl(causedBy = Option(causedBy))
 
   override def apply(id: AnomalyID, message: String, causedBy: Throwable): DeniedFailure =

--- a/core/src/main/scala/busymachines/core/deniedAnomaly.scala
+++ b/core/src/main/scala/busymachines/core/deniedAnomaly.scala
@@ -94,6 +94,9 @@ object DeniedFailure extends FailureConstructors[DeniedFailure] {
 
   override def apply(a: Anomaly): DeniedFailure =
     DeniedFailureImpl(id = a.id, message = a.message, parameters = a.parameters)
+
+  override def apply(message: String, causedBy: Throwable): DeniedFailure =
+    DeniedFailureImpl(message = message, causedBy = Option(causedBy))
 }
 
 private[core] final case class DeniedFailureImpl(

--- a/core/src/main/scala/busymachines/core/exceptions/errors.scala
+++ b/core/src/main/scala/busymachines/core/exceptions/errors.scala
@@ -9,17 +9,21 @@ package busymachines.core.exceptions
   * Since the types here are a minority, the design here emulates the one
   * from the other more commonly used file.
   */
+@scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
 trait ErrorMessage extends FailureMessage
 
+@scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
 abstract class Error(
   override val message: String,
   val cause:            Option[Throwable] = None
 ) extends Exception(message, cause.orNull) with FailureMessage with ErrorMessage
 
+@scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
 object Error extends Error(SemanticErrors.Error, None) {
 
   override def id: FailureID = SemanticErrors.GenericErrorID
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   private final class ReifiedError(
     message: String,
     cause:   Option[Throwable] = None
@@ -27,12 +31,15 @@ object Error extends Error(SemanticErrors.Error, None) {
     override def id: FailureID = SemanticErrors.GenericErrorID
   }
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(msg: String): Error =
     new ReifiedError(msg)
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(msg: String, cause: Throwable): Error =
     new ReifiedError(msg, Some(cause))
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(cause: Throwable): Error =
     new ReifiedError(cause.getMessage, Some(cause))
 }
@@ -41,20 +48,26 @@ object Error extends Error(SemanticErrors.Error, None) {
 //=============================================================================
 //=============================================================================
 
+@scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
 object SemanticErrors {
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   trait InconsistentState
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   private[exceptions] case object InconsistentStateID extends FailureID {
     override def name: String = "is_state"
   }
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   private[exceptions] val `Inconsistent state` = "Inconsistent state error"
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   private[exceptions] case object GenericErrorID extends FailureID {
     override def name: String = "error"
   }
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   private[exceptions] val `Error` = "Error"
 }
 
@@ -62,15 +75,19 @@ object SemanticErrors {
   *
   * See [[SemanticErrors.InconsistentState]] for intended use.
   */
+@scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
 abstract class InconsistentStateError(
   message: String,
   cause:   Option[Throwable] = None
 ) extends Error(message, cause) with SemanticErrors.InconsistentState
 
+@scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
 object InconsistentStateError extends InconsistentStateError(SemanticErrors.`Inconsistent state`, None) {
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   override def id: FailureID = SemanticErrors.InconsistentStateID
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   private final class ReifiedInconsistentStateError(
     message: String,
     cause:   Option[Throwable] = None
@@ -78,12 +95,15 @@ object InconsistentStateError extends InconsistentStateError(SemanticErrors.`Inc
     override def id: FailureID = SemanticErrors.InconsistentStateID
   }
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(msg: String): InconsistentStateError =
     new ReifiedInconsistentStateError(msg)
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(msg: String, cause: Throwable): InconsistentStateError =
     new ReifiedInconsistentStateError(msg, Some(cause))
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(cause: Throwable): InconsistentStateError =
     new ReifiedInconsistentStateError(cause.getMessage, Some(cause))
 }

--- a/core/src/main/scala/busymachines/core/exceptions/failures.scala
+++ b/core/src/main/scala/busymachines/core/exceptions/failures.scala
@@ -91,24 +91,32 @@ import scala.collection.immutable
   * @since 31 Jul 2017
   *
   */
+@scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
 trait FailureID {
   def name: String
 }
 
+@scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
 object FailureID {
 
   private case class GenericFailureID(override val name: String) extends FailureID
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(id: String): FailureID = GenericFailureID(id)
 }
 
+@scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
 object FailureMessage {
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   type ParamValue = StringOrSeqString
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   object ParamValue {
+    @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
     def apply(s: String) = StringWrapper(s)
 
+    @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
     def apply(ses: immutable.Seq[String]) = SeqStringWrapper(ses)
   }
 
@@ -117,26 +125,35 @@ object FailureMessage {
     * Until then, boiler plate freedom is given by the implicit
     * conversions found in the package object
     */
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   sealed trait StringOrSeqString
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   final case class StringWrapper private (s: String) extends ParamValue
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   final case class SeqStringWrapper private (ses: immutable.Seq[String]) extends ParamValue
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   type Parameters = Map[String, ParamValue]
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   object Parameters {
+    @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
     def apply(ps: (String, ParamValue)*): Parameters = Map.apply(ps: _*)
 
+    @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
     def empty: Parameters = Map.empty[String, ParamValue]
   }
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   private final case class GenericFailureMessage(
     override val id:         FailureID,
     override val message:    String,
     override val parameters: Parameters
   ) extends FailureMessage
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(
     id:         FailureID,
     message:    String,
@@ -146,11 +163,15 @@ object FailureMessage {
   }
 }
 
+@scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
 trait FailureMessage {
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def id: FailureID
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def message: String
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def parameters: FailureMessage.Parameters = FailureMessage.Parameters.empty
 }
 
@@ -164,35 +185,47 @@ trait FailureMessage {
   *
   * Guaranteed to have non-empty FailureMessages
   */
+@scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
 trait FailureMessages extends FailureMessage {
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def firstMessage: FailureMessage
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def restOfMessages: immutable.Seq[FailureMessage]
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   final def messages: immutable.Seq[FailureMessage] =
     firstMessage +: restOfMessages
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   final def hasNotFound: Boolean =
     messages.exists(_.isInstanceOf[NotFoundFailure])
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   final def hasUnauthorized: Boolean =
     messages.exists(_.isInstanceOf[UnauthorizedFailure])
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   final def hasForbidden: Boolean =
     messages.exists(_.isInstanceOf[ForbiddenFailure])
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   final def hasDenied: Boolean =
     messages.exists(_.isInstanceOf[DeniedFailure])
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   final def hasInvalidInput: Boolean =
     messages.exists(_.isInstanceOf[InvalidInputFailure])
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   final def hasConflict: Boolean =
     messages.exists(_.isInstanceOf[ConflictFailure])
 }
 
+@scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
 object FailureMessages {
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   private final case class GenericFailureMessages(
     override val id:             FailureID,
     override val message:        String,
@@ -200,6 +233,7 @@ object FailureMessages {
     override val restOfMessages: immutable.Seq[FailureMessage],
   ) extends FailureMessages
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(id: FailureID, message: String, msg: FailureMessage, msgs: FailureMessage*): FailureMessages = {
     GenericFailureMessages(id, message, msg, msgs.toList)
   }
@@ -210,14 +244,17 @@ object FailureMessages {
   *
   * Most likely you need to extend one of the other cases.
   */
+@scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
 abstract class FailureBase(
   override val message:    String,
   val cause:               Option[Throwable] = None,
   override val parameters: FailureMessage.Parameters = FailureMessage.Parameters.empty
 ) extends Exception(message, cause.orNull) with FailureMessage
 
+@scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
 object FailureBase {
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   private final class ReifiedFailure(
     override val id:         FailureID,
     override val message:    String,
@@ -229,10 +266,12 @@ object FailureBase {
         parameters = parameters
       )
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(fm: FailureMessage): FailureBase = {
     new ReifiedFailure(fm.id, fm.message, fm.parameters, None)
   }
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(fm: FailureMessage, cause: Throwable): FailureBase = {
     new ReifiedFailure(fm.id, fm.message, fm.parameters, Option(cause))
   }
@@ -243,6 +282,7 @@ object FailureBase {
   *
   * Primarily used as containers for validation failures.
   */
+@scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
 abstract class Failures(
   override val id:             FailureID,
   override val message:        String,
@@ -250,8 +290,10 @@ abstract class Failures(
   override val restOfMessages: immutable.Seq[FailureMessage],
 ) extends Exception(message) with FailureMessages
 
+@scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
 object Failures {
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   private final class ReifiedFailures(
     id:             FailureID,
     message:        String,
@@ -267,6 +309,7 @@ object Failures {
   * Marker traits, so that both the [[FailureBase]] and [[Failures]]
   * can be marked with the same semantic meaning
   */
+@scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
 object SemanticFailures {
 
   /**
@@ -275,12 +318,15 @@ object SemanticFailures {
     * "you cannot find something; it may or may not exist, and I'm not going
     * to tell you anything else"
     */
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   trait NotFound
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   private[exceptions] case object NotFoundID extends FailureID {
     override def name: String = "0"
   }
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   private[exceptions] val `Not found` = "Not found"
 
   /**
@@ -289,12 +335,15 @@ object SemanticFailures {
     * "something is wrong in the way you authorized, you can try again slightly
     * differently"
     */
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   trait Unauthorized
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   private[exceptions] case object UnauthorizedID extends FailureID {
     override def name: String = "1"
   }
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   private[exceptions] val `Unauthorized` = "Unauthorized"
 
   /**
@@ -303,12 +352,15 @@ object SemanticFailures {
     * "it exists, but you're not even allowed to know about that;
     * so for short, you can't find it".
     */
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   trait Forbidden
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   private[exceptions] case object ForbiddenID extends FailureID {
     override def name: String = "2"
   }
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   private[exceptions] val `Forbidden` = "Forbidden"
 
   /**
@@ -316,12 +368,15 @@ object SemanticFailures {
     *
     * "you know it exists, but you are not allowed to see it"
     */
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   trait Denied
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   private[exceptions] case object DeniedID extends FailureID {
     override def name: String = "3"
   }
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   private[exceptions] val `Denied` = "Denied"
 
   /**
@@ -342,12 +397,15 @@ object SemanticFailures {
     *
     * Therefore, specialize frantically.
     */
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   trait InvalidInput
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   private[exceptions] case object InvalidInputID extends FailureID {
     override def name: String = "4"
   }
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   private[exceptions] val `Invalid Input` = "Invalid input"
 
   /**
@@ -356,12 +414,15 @@ object SemanticFailures {
     * E.g. when you're duplicating something that ought to be unique,
     * like ids, emails.
     */
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   trait Conflict
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   private[exceptions] case object ConflictID extends FailureID {
     override def name: String = "5"
   }
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   private[exceptions] val `Conflict` = "Conflict"
 
 }
@@ -375,12 +436,14 @@ object SemanticFailures {
   *
   * See [[SemanticFailures.NotFound]] for intended use.
   */
+@scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
 abstract class NotFoundFailure(
   message:    String,
   cause:      Option[Throwable] = None,
   parameters: FailureMessage.Parameters = FailureMessage.Parameters.empty
 ) extends FailureBase(message, cause, parameters) with SemanticFailures.NotFound
 
+@scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
 object NotFoundFailure extends NotFoundFailure(SemanticFailures.`Not found`, None, FailureMessage.Parameters.empty) {
 
   override def id: FailureID = SemanticFailures.NotFoundID
@@ -393,15 +456,19 @@ object NotFoundFailure extends NotFoundFailure(SemanticFailures.`Not found`, Non
     override def id: FailureID = SemanticFailures.NotFoundID
   }
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(msg: String): NotFoundFailure =
     new ReifiedNotFoundFailure(message = msg, cause = None, parameters = FailureMessage.Parameters.empty)
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(msg: String, cause: Throwable): NotFoundFailure =
     new ReifiedNotFoundFailure(message = msg, cause = Some(cause), parameters = FailureMessage.Parameters.empty)
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(msg: String, params: FailureMessage.Parameters): NotFoundFailure =
     new ReifiedNotFoundFailure(message = msg, cause = None, parameters = params)
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(cause: Throwable): NotFoundFailure =
     new ReifiedNotFoundFailure(
       message    = cause.getMessage,
@@ -409,9 +476,11 @@ object NotFoundFailure extends NotFoundFailure(SemanticFailures.`Not found`, Non
       parameters = FailureMessage.Parameters.empty
     )
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(cause: Throwable, params: FailureMessage.Parameters): NotFoundFailure =
     new ReifiedNotFoundFailure(message = cause.getMessage, cause = None, parameters = params)
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(msg: String, cause: Throwable, params: FailureMessage.Parameters): NotFoundFailure =
     new ReifiedNotFoundFailure(message = msg, cause = Some(cause), parameters = params)
 }
@@ -425,17 +494,20 @@ object NotFoundFailure extends NotFoundFailure(SemanticFailures.`Not found`, Non
   *
   * See [[SemanticFailures.Unauthorized]] for intended use.
   */
+@scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
 abstract class UnauthorizedFailure(
   message:    String,
   cause:      Option[Throwable] = None,
   parameters: FailureMessage.Parameters = FailureMessage.Parameters.empty
 ) extends FailureBase(message, cause, parameters) with SemanticFailures.Unauthorized
 
+@scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
 object UnauthorizedFailure
     extends UnauthorizedFailure(SemanticFailures.`Unauthorized`, None, FailureMessage.Parameters.empty) {
 
   override def id: FailureID = SemanticFailures.UnauthorizedID
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   private final class ReifiedUnauthorizedFailure(
     message:    String,
     cause:      Option[Throwable],
@@ -444,15 +516,19 @@ object UnauthorizedFailure
     override def id: FailureID = SemanticFailures.UnauthorizedID
   }
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(msg: String): UnauthorizedFailure =
     new ReifiedUnauthorizedFailure(message = msg, cause = None, parameters = FailureMessage.Parameters.empty)
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(msg: String, cause: Throwable): UnauthorizedFailure =
     new ReifiedUnauthorizedFailure(message = msg, cause = Some(cause), parameters = FailureMessage.Parameters.empty)
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(msg: String, params: FailureMessage.Parameters): UnauthorizedFailure =
     new ReifiedUnauthorizedFailure(message = msg, cause = None, parameters = params)
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(cause: Throwable): UnauthorizedFailure =
     new ReifiedUnauthorizedFailure(
       message    = cause.getMessage,
@@ -460,9 +536,11 @@ object UnauthorizedFailure
       parameters = FailureMessage.Parameters.empty
     )
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(cause: Throwable, params: FailureMessage.Parameters): UnauthorizedFailure =
     new ReifiedUnauthorizedFailure(message = cause.getMessage, cause = None, parameters = params)
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(msg: String, cause: Throwable, params: FailureMessage.Parameters): UnauthorizedFailure =
     new ReifiedUnauthorizedFailure(message = msg, cause = Some(cause), parameters = params)
 }
@@ -476,16 +554,20 @@ object UnauthorizedFailure
   *
   * See [[SemanticFailures.Forbidden]] for intended use.
   */
+@scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
 abstract class ForbiddenFailure(
   message:    String,
   cause:      Option[Throwable] = None,
   parameters: FailureMessage.Parameters = FailureMessage.Parameters.empty
 ) extends FailureBase(message, cause, parameters) with SemanticFailures.Forbidden
 
+@scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
 object ForbiddenFailure extends ForbiddenFailure(SemanticFailures.`Forbidden`, None, FailureMessage.Parameters.empty) {
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   override def id: FailureID = SemanticFailures.ForbiddenID
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   private final class ReifiedForbiddenFailure(
     message:    String,
     cause:      Option[Throwable],
@@ -494,15 +576,19 @@ object ForbiddenFailure extends ForbiddenFailure(SemanticFailures.`Forbidden`, N
     override def id: FailureID = SemanticFailures.ForbiddenID
   }
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(msg: String): ForbiddenFailure =
     new ReifiedForbiddenFailure(message = msg, cause = None, parameters = FailureMessage.Parameters.empty)
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(msg: String, cause: Throwable): ForbiddenFailure =
     new ReifiedForbiddenFailure(message = msg, cause = Some(cause), parameters = FailureMessage.Parameters.empty)
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(msg: String, params: FailureMessage.Parameters): ForbiddenFailure =
     new ReifiedForbiddenFailure(message = msg, cause = None, parameters = params)
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(cause: Throwable): ForbiddenFailure =
     new ReifiedForbiddenFailure(
       message    = cause.getMessage,
@@ -510,9 +596,11 @@ object ForbiddenFailure extends ForbiddenFailure(SemanticFailures.`Forbidden`, N
       parameters = FailureMessage.Parameters.empty
     )
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(cause: Throwable, params: FailureMessage.Parameters): ForbiddenFailure =
     new ReifiedForbiddenFailure(message = cause.getMessage, cause = None, parameters = params)
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(msg: String, cause: Throwable, params: FailureMessage.Parameters): ForbiddenFailure =
     new ReifiedForbiddenFailure(message = msg, cause = Some(cause), parameters = params)
 }
@@ -526,16 +614,19 @@ object ForbiddenFailure extends ForbiddenFailure(SemanticFailures.`Forbidden`, N
   *
   * See [[SemanticFailures.Denied]] for intended use.
   */
+@scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
 abstract class DeniedFailure(
   message:    String,
   cause:      Option[Throwable] = None,
   parameters: FailureMessage.Parameters = FailureMessage.Parameters.empty
 ) extends FailureBase(message, cause, parameters) with SemanticFailures.Denied
 
+@scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
 object DeniedFailure extends DeniedFailure(SemanticFailures.`Denied`, None, FailureMessage.Parameters.empty) {
 
   override def id: FailureID = SemanticFailures.DeniedID
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   private final class ReifiedDeniedFailure(
     message:    String,
     cause:      Option[Throwable],
@@ -544,15 +635,19 @@ object DeniedFailure extends DeniedFailure(SemanticFailures.`Denied`, None, Fail
     override def id: FailureID = SemanticFailures.DeniedID
   }
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(msg: String): DeniedFailure =
     new ReifiedDeniedFailure(message = msg, cause = None, parameters = FailureMessage.Parameters.empty)
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(msg: String, cause: Throwable): DeniedFailure =
     new ReifiedDeniedFailure(message = msg, cause = Some(cause), parameters = FailureMessage.Parameters.empty)
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(msg: String, params: FailureMessage.Parameters): DeniedFailure =
     new ReifiedDeniedFailure(message = msg, cause = None, parameters = params)
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(cause: Throwable): DeniedFailure =
     new ReifiedDeniedFailure(
       message    = cause.getMessage,
@@ -560,9 +655,11 @@ object DeniedFailure extends DeniedFailure(SemanticFailures.`Denied`, None, Fail
       parameters = FailureMessage.Parameters.empty
     )
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(cause: Throwable, params: FailureMessage.Parameters): DeniedFailure =
     new ReifiedDeniedFailure(message = cause.getMessage, cause = None, parameters = params)
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(msg: String, cause: Throwable, params: FailureMessage.Parameters): DeniedFailure =
     new ReifiedDeniedFailure(message = msg, cause = Some(cause), parameters = params)
 }
@@ -576,17 +673,20 @@ object DeniedFailure extends DeniedFailure(SemanticFailures.`Denied`, None, Fail
   *
   * See [[SemanticFailures.InvalidInput]] for intended use.
   */
+@scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
 abstract class InvalidInputFailure(
   message:    String,
   cause:      Option[Throwable] = None,
   parameters: FailureMessage.Parameters = FailureMessage.Parameters.empty
 ) extends FailureBase(message, cause, parameters) with SemanticFailures.InvalidInput
 
+@scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
 object InvalidInputFailure
     extends InvalidInputFailure(SemanticFailures.`Invalid Input`, None, FailureMessage.Parameters.empty) {
 
   override def id: FailureID = SemanticFailures.InvalidInputID
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   private final class ReifiedInvalidInputFailure(
     message:    String,
     cause:      Option[Throwable],
@@ -595,15 +695,19 @@ object InvalidInputFailure
     override def id: FailureID = SemanticFailures.InvalidInputID
   }
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(msg: String): InvalidInputFailure =
     new ReifiedInvalidInputFailure(message = msg, cause = None, parameters = FailureMessage.Parameters.empty)
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(msg: String, cause: Throwable): InvalidInputFailure =
     new ReifiedInvalidInputFailure(message = msg, cause = Some(cause), parameters = FailureMessage.Parameters.empty)
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(msg: String, params: FailureMessage.Parameters): InvalidInputFailure =
     new ReifiedInvalidInputFailure(message = msg, cause = None, parameters = params)
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(cause: Throwable): InvalidInputFailure =
     new ReifiedInvalidInputFailure(
       message    = cause.getMessage,
@@ -611,9 +715,11 @@ object InvalidInputFailure
       parameters = FailureMessage.Parameters.empty
     )
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(cause: Throwable, params: FailureMessage.Parameters): InvalidInputFailure =
     new ReifiedInvalidInputFailure(message = cause.getMessage, cause = None, parameters = params)
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(msg: String, cause: Throwable, params: FailureMessage.Parameters): InvalidInputFailure =
     new ReifiedInvalidInputFailure(message = msg, cause = Some(cause), parameters = params)
 }
@@ -627,16 +733,19 @@ object InvalidInputFailure
   *
   * See [[SemanticFailures.Conflict]] for intended use.
   */
+@scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
 abstract class ConflictFailure(
   message:    String,
   cause:      Option[Throwable] = None,
   parameters: FailureMessage.Parameters = FailureMessage.Parameters.empty
 ) extends FailureBase(message, cause, parameters) with SemanticFailures.Conflict
 
+@scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
 object ConflictFailure extends ConflictFailure(SemanticFailures.`Conflict`, None, FailureMessage.Parameters.empty) {
 
   override def id: FailureID = SemanticFailures.ConflictID
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   private final class ReifiedConflictFailure(
     message:    String,
     cause:      Option[Throwable],
@@ -645,15 +754,19 @@ object ConflictFailure extends ConflictFailure(SemanticFailures.`Conflict`, None
     override def id: FailureID = SemanticFailures.ConflictID
   }
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(msg: String): ConflictFailure =
     new ReifiedConflictFailure(message = msg, cause = None, parameters = FailureMessage.Parameters.empty)
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(msg: String, cause: Throwable): ConflictFailure =
     new ReifiedConflictFailure(message = msg, cause = Some(cause), parameters = FailureMessage.Parameters.empty)
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(msg: String, params: FailureMessage.Parameters): ConflictFailure =
     new ReifiedConflictFailure(message = msg, cause = None, parameters = params)
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(cause: Throwable): ConflictFailure =
     new ReifiedConflictFailure(
       message    = cause.getMessage,
@@ -661,9 +774,11 @@ object ConflictFailure extends ConflictFailure(SemanticFailures.`Conflict`, None
       parameters = FailureMessage.Parameters.empty
     )
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(cause: Throwable, params: FailureMessage.Parameters): ConflictFailure =
     new ReifiedConflictFailure(message = cause.getMessage, cause = None, parameters = params)
 
+  @scala.deprecated("Use the types from busymachines.core", "0.2.0-RC8")
   def apply(msg: String, cause: Throwable, params: FailureMessage.Parameters): ConflictFailure =
     new ReifiedConflictFailure(message = msg, cause = Some(cause), parameters = params)
 }

--- a/core/src/main/scala/busymachines/core/forbiddenAnomaly.scala
+++ b/core/src/main/scala/busymachines/core/forbiddenAnomaly.scala
@@ -53,7 +53,9 @@ abstract class ForbiddenFailure(
   override def id: AnomalyID = ForbiddenAnomalyID
 }
 
-object ForbiddenFailure extends FailureConstructors[ForbiddenFailure] {
+object ForbiddenFailure
+    extends ForbiddenFailure(MeaningfulAnomalies.`Forbidden`, None) with SingletonAnomalyProduct
+    with FailureConstructors[ForbiddenFailure] {
   override def apply(causedBy: Throwable): ForbiddenFailure = ForbiddenFailureImpl(causedBy = Option(causedBy))
 
   override def apply(id: AnomalyID, message: String, causedBy: Throwable): ForbiddenFailure =

--- a/core/src/main/scala/busymachines/core/forbiddenAnomaly.scala
+++ b/core/src/main/scala/busymachines/core/forbiddenAnomaly.scala
@@ -94,6 +94,9 @@ object ForbiddenFailure extends FailureConstructors[ForbiddenFailure] {
 
   override def apply(a: Anomaly): ForbiddenFailure =
     ForbiddenFailureImpl(id = a.id, message = a.message, parameters = a.parameters)
+
+  override def apply(message: String, causedBy: Throwable): ForbiddenFailure =
+    ForbiddenFailureImpl(message = message, causedBy = Option(causedBy))
 }
 
 private[core] final case class ForbiddenFailureImpl(

--- a/core/src/main/scala/busymachines/core/forbiddenAnomaly.scala
+++ b/core/src/main/scala/busymachines/core/forbiddenAnomaly.scala
@@ -37,7 +37,7 @@ private[core] final case class ForbiddenAnomalyImpl(
   override val id:         AnomalyID  = ForbiddenAnomalyID,
   override val message:    String     = MeaningfulAnomalies.`Forbidden`,
   override val parameters: Parameters = Parameters.empty
-) extends ForbiddenAnomaly {
+) extends ForbiddenAnomaly with Product with Serializable {
 
   override def asThrowable: Throwable = ForbiddenFailureImpl(id, message, parameters)
 }
@@ -49,7 +49,7 @@ private[core] final case class ForbiddenAnomalyImpl(
 abstract class ForbiddenFailure(
   override val message: String,
   causedBy:             Option[Throwable] = None,
-) extends AnomalousFailure(message, causedBy) with ForbiddenAnomaly {
+) extends AnomalousFailure(message, causedBy) with ForbiddenAnomaly with Product with Serializable {
   override def id: AnomalyID = ForbiddenAnomalyID
 }
 
@@ -101,4 +101,4 @@ private[core] final case class ForbiddenFailureImpl(
   override val message:    String            = MeaningfulAnomalies.`Forbidden`,
   override val parameters: Parameters        = Parameters.empty,
   causedBy:                Option[Throwable] = None,
-) extends ForbiddenFailure(message, causedBy)
+) extends ForbiddenFailure(message, causedBy) with Product with Serializable

--- a/core/src/main/scala/busymachines/core/forbiddenAnomaly.scala
+++ b/core/src/main/scala/busymachines/core/forbiddenAnomaly.scala
@@ -1,0 +1,104 @@
+package busymachines.core
+
+import busymachines.core.Anomaly.Parameters
+
+/**
+  *
+  * @author Lorand Szakacs, lsz@lorandszakacs.com, lorand.szakacs@busymachines.com
+  * @since 26 Dec 2017
+  *
+  */
+trait ForbiddenAnomaly extends Anomaly with MeaningfulAnomalies.Forbidden with Product with Serializable
+
+object ForbiddenAnomaly extends AnomalyConstructors[ForbiddenAnomaly] {
+  override def apply(id: AnomalyID): ForbiddenAnomaly = ForbiddenAnomalyImpl(id = id)
+
+  override def apply(message: String): ForbiddenAnomaly = ForbiddenAnomalyImpl(message = message)
+
+  override def apply(parameters: Parameters): ForbiddenAnomaly = ForbiddenAnomalyImpl(parameters = parameters)
+
+  override def apply(id: AnomalyID, message: String): ForbiddenAnomaly =
+    ForbiddenAnomalyImpl(id = id, message = message)
+
+  override def apply(id: AnomalyID, parameters: Parameters): ForbiddenAnomaly =
+    ForbiddenAnomalyImpl(id = id, parameters = parameters)
+
+  override def apply(message: String, parameters: Parameters): ForbiddenAnomaly =
+    ForbiddenAnomalyImpl(message = message, parameters = parameters)
+
+  override def apply(id: AnomalyID, message: String, parameters: Parameters): ForbiddenAnomaly =
+    ForbiddenAnomalyImpl(id = id, message = message, parameters = parameters)
+
+  override def apply(a: Anomaly): ForbiddenAnomaly =
+    ForbiddenAnomalyImpl(id = a.id, message = a.message, parameters = a.parameters)
+}
+
+private[core] final case class ForbiddenAnomalyImpl(
+  override val id:         AnomalyID  = ForbiddenAnomalyID,
+  override val message:    String     = MeaningfulAnomalies.`Forbidden`,
+  override val parameters: Parameters = Parameters.empty
+) extends ForbiddenAnomaly {
+
+  override def asThrowable: Throwable = ForbiddenFailureImpl(id, message, parameters)
+}
+
+//=============================================================================
+//=============================================================================
+//=============================================================================
+
+abstract class ForbiddenFailure(
+  override val message: String,
+  causedBy:             Option[Throwable] = None,
+) extends AnomalousFailure(message, causedBy) with ForbiddenAnomaly {
+  override def id: AnomalyID = ForbiddenAnomalyID
+}
+
+object ForbiddenFailure extends FailureConstructors[ForbiddenFailure] {
+  override def apply(causedBy: Throwable): ForbiddenFailure = ForbiddenFailureImpl(causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID, message: String, causedBy: Throwable): ForbiddenFailure =
+    ForbiddenFailureImpl(id = id, message = message, causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID, parameters: Parameters, causedBy: Throwable): ForbiddenFailure =
+    ForbiddenFailureImpl(id = id, parameters = parameters, causedBy = Option(causedBy))
+
+  override def apply(message: String, parameters: Parameters, causedBy: Throwable): ForbiddenFailure =
+    ForbiddenFailureImpl(message = message, parameters = parameters, causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID, message: String, parameters: Parameters, causedBy: Throwable): ForbiddenFailure =
+    ForbiddenFailureImpl(id = id, message = message, parameters = parameters, causedBy = Option(causedBy))
+
+  override def apply(a: Anomaly, causedBy: Throwable): ForbiddenFailure =
+    ForbiddenFailureImpl(id = a.id, message = a.message, parameters = a.parameters, causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID): ForbiddenFailure =
+    ForbiddenFailureImpl(id = id)
+
+  override def apply(message: String): ForbiddenFailure =
+    ForbiddenFailureImpl(message = message)
+
+  override def apply(parameters: Parameters): ForbiddenFailure =
+    ForbiddenFailureImpl(parameters = parameters)
+
+  override def apply(id: AnomalyID, message: String): ForbiddenFailure =
+    ForbiddenFailureImpl(id = id, message = message)
+
+  override def apply(id: AnomalyID, parameters: Parameters): ForbiddenFailure =
+    ForbiddenFailureImpl(id = id, parameters = parameters)
+
+  override def apply(message: String, parameters: Parameters): ForbiddenFailure =
+    ForbiddenFailureImpl(message = message, parameters = parameters)
+
+  override def apply(id: AnomalyID, message: String, parameters: Parameters): ForbiddenFailure =
+    ForbiddenFailureImpl(id = id, message = message, parameters = parameters)
+
+  override def apply(a: Anomaly): ForbiddenFailure =
+    ForbiddenFailureImpl(id = a.id, message = a.message, parameters = a.parameters)
+}
+
+private[core] final case class ForbiddenFailureImpl(
+  override val id:         AnomalyID         = ForbiddenAnomalyID,
+  override val message:    String            = MeaningfulAnomalies.`Forbidden`,
+  override val parameters: Parameters        = Parameters.empty,
+  causedBy:                Option[Throwable] = None,
+) extends ForbiddenFailure(message, causedBy)

--- a/core/src/main/scala/busymachines/core/implementationHelpers.scala
+++ b/core/src/main/scala/busymachines/core/implementationHelpers.scala
@@ -1,0 +1,43 @@
+package busymachines.core
+
+import busymachines.core.Anomaly.Parameters
+
+/**
+  * Nothing from this file should ever escape [[busymachines.core]]
+  *
+  * @author Lorand Szakacs, lsz@lorandszakacs.com, lorand.szakacs@busymachines.com
+  * @since 26 Dec 2017
+  *
+  */
+private[core] trait AnomalyConstructors[Resulting <: Anomaly] {
+  def apply(id: AnomalyID): Resulting
+
+  def apply(message: String): Resulting
+
+  def apply(parameters: Parameters): Resulting
+
+  def apply(id: AnomalyID, message: String): Resulting
+
+  def apply(id: AnomalyID, parameters: Parameters): Resulting
+
+  def apply(message: String, parameters: Parameters): Resulting
+
+  def apply(id: AnomalyID, message: String, parameters: Parameters): Resulting
+
+  def apply(a: Anomaly): Resulting
+}
+
+private[core] trait FailureConstructors[Resulting <: AnomalousFailure] extends AnomalyConstructors[Resulting] {
+
+  def apply(causedBy: Throwable): Resulting
+
+  def apply(id: AnomalyID, message: String, causedBy: Throwable): Resulting
+
+  def apply(id: AnomalyID, parameters: Parameters, causedBy: Throwable): Resulting
+
+  def apply(message: String, parameters: Parameters, causedBy: Throwable): Resulting
+
+  def apply(id: AnomalyID, message: String, parameters: Parameters, causedBy: Throwable): Resulting
+
+  def apply(a: Anomaly, causedBy: Throwable): Resulting
+}

--- a/core/src/main/scala/busymachines/core/implementationHelpers.scala
+++ b/core/src/main/scala/busymachines/core/implementationHelpers.scala
@@ -41,3 +41,18 @@ private[core] trait FailureConstructors[Resulting <: AnomalousFailure] extends A
 
   def apply(a: Anomaly, causedBy: Throwable): Resulting
 }
+
+private[core] trait CatastrophicErrorConstructors[Resulting <: CatastrophicError] extends AnomalyConstructors[Resulting] {
+
+  def apply(causedBy: Throwable): Resulting
+
+  def apply(id: AnomalyID, message: String, causedBy: Throwable): Resulting
+
+  def apply(id: AnomalyID, parameters: Parameters, causedBy: Throwable): Resulting
+
+  def apply(message: String, parameters: Parameters, causedBy: Throwable): Resulting
+
+  def apply(id: AnomalyID, message: String, parameters: Parameters, causedBy: Throwable): Resulting
+
+  def apply(a: Anomaly, causedBy: Throwable): Resulting
+}

--- a/core/src/main/scala/busymachines/core/implementationHelpers.scala
+++ b/core/src/main/scala/busymachines/core/implementationHelpers.scala
@@ -31,6 +31,8 @@ private[core] trait FailureConstructors[Resulting <: AnomalousFailure] extends A
 
   def apply(causedBy: Throwable): Resulting
 
+  def apply(message: String, causedBy: Throwable): Resulting
+
   def apply(id: AnomalyID, message: String, causedBy: Throwable): Resulting
 
   def apply(id: AnomalyID, parameters: Parameters, causedBy: Throwable): Resulting
@@ -45,6 +47,8 @@ private[core] trait FailureConstructors[Resulting <: AnomalousFailure] extends A
 private[core] trait CatastrophicErrorConstructors[Resulting <: CatastrophicError] extends AnomalyConstructors[Resulting] {
 
   def apply(causedBy: Throwable): Resulting
+
+  def apply(message: String, causedBy: Throwable): Resulting
 
   def apply(id: AnomalyID, message: String, causedBy: Throwable): Resulting
 

--- a/core/src/main/scala/busymachines/core/implementationHelpers.scala
+++ b/core/src/main/scala/busymachines/core/implementationHelpers.scala
@@ -44,7 +44,8 @@ private[core] trait FailureConstructors[Resulting <: AnomalousFailure] extends A
   def apply(a: Anomaly, causedBy: Throwable): Resulting
 }
 
-private[core] trait CatastrophicErrorConstructors[Resulting <: CatastrophicError] extends AnomalyConstructors[Resulting] {
+private[core] trait CatastrophicErrorConstructors[Resulting <: CatastrophicError]
+    extends AnomalyConstructors[Resulting] {
 
   def apply(causedBy: Throwable): Resulting
 
@@ -59,4 +60,18 @@ private[core] trait CatastrophicErrorConstructors[Resulting <: CatastrophicError
   def apply(id: AnomalyID, message: String, parameters: Parameters, causedBy: Throwable): Resulting
 
   def apply(a: Anomaly, causedBy: Throwable): Resulting
+}
+
+private[core] trait SingletonAnomalyProduct extends Product with Serializable {
+  this: Anomaly =>
+  override def productElement(n: Int): Any = n match {
+    case 0 => id
+    case 1 => message
+    case 2 => parameters
+    case i => throw new IndexOutOfBoundsException(s"Anomaly has only 3 elements, index 0-2. Trying to get $i")
+  }
+
+  override def productArity: Int = 3
+
+  override def canEqual(that: Any): Boolean = that.isInstanceOf[Anomaly]
 }

--- a/core/src/main/scala/busymachines/core/invalidInputAnomaly.scala
+++ b/core/src/main/scala/busymachines/core/invalidInputAnomaly.scala
@@ -94,6 +94,9 @@ object InvalidInputFailure extends FailureConstructors[InvalidInputFailure] {
 
   override def apply(a: Anomaly): InvalidInputFailure =
     InvalidInputFailureImpl(id = a.id, message = a.message, parameters = a.parameters)
+
+  override def apply(message: String, causedBy: Throwable): InvalidInputFailure =
+    InvalidInputFailureImpl(message = message, causedBy = Option(causedBy))
 }
 
 private[core] final case class InvalidInputFailureImpl(

--- a/core/src/main/scala/busymachines/core/invalidInputAnomaly.scala
+++ b/core/src/main/scala/busymachines/core/invalidInputAnomaly.scala
@@ -53,7 +53,9 @@ abstract class InvalidInputFailure(
   override def id: AnomalyID = InvalidInputAnomalyID
 }
 
-object InvalidInputFailure extends FailureConstructors[InvalidInputFailure] {
+object InvalidInputFailure
+    extends InvalidInputFailure(MeaningfulAnomalies.`Invalid Input`, None) with SingletonAnomalyProduct with
+      FailureConstructors[InvalidInputFailure] {
   override def apply(causedBy: Throwable): InvalidInputFailure = InvalidInputFailureImpl(causedBy = Option(causedBy))
 
   override def apply(id: AnomalyID, message: String, causedBy: Throwable): InvalidInputFailure =

--- a/core/src/main/scala/busymachines/core/invalidInputAnomaly.scala
+++ b/core/src/main/scala/busymachines/core/invalidInputAnomaly.scala
@@ -37,7 +37,7 @@ private[core] final case class InvalidInputAnomalyImpl(
   override val id:         AnomalyID  = InvalidInputAnomalyID,
   override val message:    String     = MeaningfulAnomalies.`Invalid Input`,
   override val parameters: Parameters = Parameters.empty
-) extends InvalidInputAnomaly {
+) extends InvalidInputAnomaly with Product with Serializable {
 
   override def asThrowable: Throwable = InvalidInputFailureImpl(id, message, parameters)
 }
@@ -49,7 +49,7 @@ private[core] final case class InvalidInputAnomalyImpl(
 abstract class InvalidInputFailure(
   override val message: String,
   causedBy:             Option[Throwable] = None,
-) extends AnomalousFailure(message, causedBy) with InvalidInputAnomaly {
+) extends AnomalousFailure(message, causedBy) with InvalidInputAnomaly with Product with Serializable {
   override def id: AnomalyID = InvalidInputAnomalyID
 }
 
@@ -101,4 +101,4 @@ private[core] final case class InvalidInputFailureImpl(
   override val message:    String            = MeaningfulAnomalies.`Invalid Input`,
   override val parameters: Parameters        = Parameters.empty,
   causedBy:                Option[Throwable] = None,
-) extends InvalidInputFailure(message, causedBy)
+) extends InvalidInputFailure(message, causedBy) with Product with Serializable

--- a/core/src/main/scala/busymachines/core/invalidInputAnomaly.scala
+++ b/core/src/main/scala/busymachines/core/invalidInputAnomaly.scala
@@ -1,0 +1,104 @@
+package busymachines.core
+
+import busymachines.core.Anomaly.Parameters
+
+/**
+  *
+  * @author Lorand Szakacs, lsz@lorandszakacs.com, lorand.szakacs@busymachines.com
+  * @since 26 Dec 2017
+  *
+  */
+trait InvalidInputAnomaly extends Anomaly with MeaningfulAnomalies.InvalidInput with Product with Serializable
+
+object InvalidInputAnomaly extends AnomalyConstructors[InvalidInputAnomaly] {
+  override def apply(id: AnomalyID): InvalidInputAnomaly = InvalidInputAnomalyImpl(id = id)
+
+  override def apply(message: String): InvalidInputAnomaly = InvalidInputAnomalyImpl(message = message)
+
+  override def apply(parameters: Parameters): InvalidInputAnomaly = InvalidInputAnomalyImpl(parameters = parameters)
+
+  override def apply(id: AnomalyID, message: String): InvalidInputAnomaly =
+    InvalidInputAnomalyImpl(id = id, message = message)
+
+  override def apply(id: AnomalyID, parameters: Parameters): InvalidInputAnomaly =
+    InvalidInputAnomalyImpl(id = id, parameters = parameters)
+
+  override def apply(message: String, parameters: Parameters): InvalidInputAnomaly =
+    InvalidInputAnomalyImpl(message = message, parameters = parameters)
+
+  override def apply(id: AnomalyID, message: String, parameters: Parameters): InvalidInputAnomaly =
+    InvalidInputAnomalyImpl(id = id, message = message, parameters = parameters)
+
+  override def apply(a: Anomaly): InvalidInputAnomaly =
+    InvalidInputAnomalyImpl(id = a.id, message = a.message, parameters = a.parameters)
+}
+
+private[core] final case class InvalidInputAnomalyImpl(
+  override val id:         AnomalyID  = InvalidInputAnomalyID,
+  override val message:    String     = MeaningfulAnomalies.`Invalid Input`,
+  override val parameters: Parameters = Parameters.empty
+) extends InvalidInputAnomaly {
+
+  override def asThrowable: Throwable = InvalidInputFailureImpl(id, message, parameters)
+}
+
+//=============================================================================
+//=============================================================================
+//=============================================================================
+
+abstract class InvalidInputFailure(
+  override val message: String,
+  causedBy:             Option[Throwable] = None,
+) extends AnomalousFailure(message, causedBy) with InvalidInputAnomaly {
+  override def id: AnomalyID = InvalidInputAnomalyID
+}
+
+object InvalidInputFailure extends FailureConstructors[InvalidInputFailure] {
+  override def apply(causedBy: Throwable): InvalidInputFailure = InvalidInputFailureImpl(causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID, message: String, causedBy: Throwable): InvalidInputFailure =
+    InvalidInputFailureImpl(id = id, message = message, causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID, parameters: Parameters, causedBy: Throwable): InvalidInputFailure =
+    InvalidInputFailureImpl(id = id, parameters = parameters, causedBy = Option(causedBy))
+
+  override def apply(message: String, parameters: Parameters, causedBy: Throwable): InvalidInputFailure =
+    InvalidInputFailureImpl(message = message, parameters = parameters, causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID, message: String, parameters: Parameters, causedBy: Throwable): InvalidInputFailure =
+    InvalidInputFailureImpl(id = id, message = message, parameters = parameters, causedBy = Option(causedBy))
+
+  override def apply(a: Anomaly, causedBy: Throwable): InvalidInputFailure =
+    InvalidInputFailureImpl(id = a.id, message = a.message, parameters = a.parameters, causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID): InvalidInputFailure =
+    InvalidInputFailureImpl(id = id)
+
+  override def apply(message: String): InvalidInputFailure =
+    InvalidInputFailureImpl(message = message)
+
+  override def apply(parameters: Parameters): InvalidInputFailure =
+    InvalidInputFailureImpl(parameters = parameters)
+
+  override def apply(id: AnomalyID, message: String): InvalidInputFailure =
+    InvalidInputFailureImpl(id = id, message = message)
+
+  override def apply(id: AnomalyID, parameters: Parameters): InvalidInputFailure =
+    InvalidInputFailureImpl(id = id, parameters = parameters)
+
+  override def apply(message: String, parameters: Parameters): InvalidInputFailure =
+    InvalidInputFailureImpl(message = message, parameters = parameters)
+
+  override def apply(id: AnomalyID, message: String, parameters: Parameters): InvalidInputFailure =
+    InvalidInputFailureImpl(id = id, message = message, parameters = parameters)
+
+  override def apply(a: Anomaly): InvalidInputFailure =
+    InvalidInputFailureImpl(id = a.id, message = a.message, parameters = a.parameters)
+}
+
+private[core] final case class InvalidInputFailureImpl(
+  override val id:         AnomalyID         = InvalidInputAnomalyID,
+  override val message:    String            = MeaningfulAnomalies.`Invalid Input`,
+  override val parameters: Parameters        = Parameters.empty,
+  causedBy:                Option[Throwable] = None,
+) extends InvalidInputFailure(message, causedBy)

--- a/core/src/main/scala/busymachines/core/meaningfulAnomalies.scala
+++ b/core/src/main/scala/busymachines/core/meaningfulAnomalies.scala
@@ -1,10 +1,26 @@
 package busymachines.core
 
 /**
+  * Some suggested naming conventions are put here so that they're easily accessible.
+  * These can also be found in the scaladoc of [[busymachines.core.AnomalyID]]
+  *
+  * - [[busymachines.core.MeaningfulAnomalies.NotFound]]
+  *   - range: 000-099; e.g. pone_001, ptwo_076, pthree_099
+  *
+  * - [[busymachines.core.MeaningfulAnomalies.Unauthorized]]
+  *   - range: 100-199; e.g. pone_100, ptwo_176, pthree_199
+  *
+  * - [[busymachines.core.MeaningfulAnomalies.Forbidden]]
+  *   - range: 200-299; e.g. pone_200, ptwo_276, pthree_299
+  *
+  * - [[busymachines.core.MeaningfulAnomalies.Denied]]
+  *   - range: 300-399; e.g. pone_300, ptwo_376, pthree_399
+  *
+  * - [[busymachines.core.MeaningfulAnomalies.InvalidInput]]
+  *   - range: 400-499; e.g. pone_400, ptwo_476, pthree_499
   *
   * @author Lorand Szakacs, lsz@lorandszakacs.com, lorand.szakacs@busymachines.com
   * @since 26 Dec 2017
-  *
   */
 object MeaningfulAnomalies {
 

--- a/core/src/main/scala/busymachines/core/meaningfulAnomalies.scala
+++ b/core/src/main/scala/busymachines/core/meaningfulAnomalies.scala
@@ -1,0 +1,99 @@
+package busymachines.core
+
+/**
+  *
+  * @author Lorand Szakacs, lsz@lorandszakacs.com, lorand.szakacs@busymachines.com
+  * @since 26 Dec 2017
+  *
+  */
+object MeaningfulAnomalies {
+
+  /**
+    * Meaning:
+    *
+    * "you cannot find something; it may or may not exist, and I'm not going
+    * to tell you anything else"
+    */
+  trait NotFound
+  private[core] val `Not found` = "Not found"
+
+  /**
+    * Meaning:
+    *
+    * "something is wrong in the way you authorized, you can try again slightly
+    * differently"
+    */
+  trait Unauthorized
+  private[core] val `Unauthorized` = "Unauthorized"
+
+  /**
+    * Meaning:
+    *
+    * "it exists, but you're not even allowed to know about that;
+    * so for short, you can't find it".
+    */
+  trait Forbidden
+  private[core] val `Forbidden` = "Forbidden"
+
+  /**
+    * Meaning:
+    *
+    * "you know it exists, but you are not allowed to see it"
+    */
+  trait Denied
+  private[core] val `Denied` = "Denied"
+
+  /**
+    * Obviously, whenever some input data is wrong.
+    *
+    * This one is probably your best friend, and the one you
+    * have to specialize the most for any given problem domain.
+    * Otherwise you just wind up with a bunch of nonsense, obtuse
+    * errors like:
+    * - "the input was wrong"
+    * - "gee, thanks, more details, please?"
+    * - sometimes you might be tempted to use NotFound, but this
+    * might be better suited. For instance, when you are dealing
+    * with a "foreign key" situation, and the foreign key is
+    * the input of the client. You'd want to be able to tell
+    * the user that their input was wrong because something was
+    * not found, not simply that it was not found.
+    *
+    * Therefore, specialize frantically.
+    */
+  trait InvalidInput
+  private[core] val `Invalid Input` = "Invalid input"
+
+  /**
+    * Special type of invalid input
+    *
+    * E.g. when you're duplicating something that ought to be unique,
+    * like ids, emails.
+    */
+  trait Conflict
+  private[core] val `Conflict` = "Conflict"
+}
+
+private[core] case object NotFoundAnomalyID extends AnomalyID {
+  override val name: String = "0"
+}
+
+private[core] case object UnauthorizedAnomalyID extends AnomalyID {
+  override val name: String = "1"
+}
+
+private[core] case object ForbiddenAnomalyID extends AnomalyID {
+  override val name: String = "2"
+}
+
+private[core] case object DeniedAnomalyID extends AnomalyID {
+  override val name: String = "3"
+}
+
+private[core] case object InvalidInputAnomalyID extends AnomalyID {
+  override val name: String = "4"
+}
+
+private[core] case object ConflictAnomalyID extends AnomalyID {
+  override val name: String = "5"
+}

--- a/core/src/main/scala/busymachines/core/notFoundAnomaly.scala
+++ b/core/src/main/scala/busymachines/core/notFoundAnomaly.scala
@@ -95,6 +95,9 @@ object NotFoundFailure extends FailureConstructors[NotFoundFailure] {
   //we intentionally not pass a causedBy a.asThrowable. Not really meaningful in this case
   override def apply(a: Anomaly): NotFoundFailure =
     NotFoundFailureImpl(id = a.id, message = a.message, parameters = a.parameters)
+
+  override def apply(message: String, causedBy: Throwable): NotFoundFailure =
+    NotFoundFailureImpl(message = message, causedBy = Option(causedBy))
 }
 
 private[core] final case class NotFoundFailureImpl(

--- a/core/src/main/scala/busymachines/core/notFoundAnomaly.scala
+++ b/core/src/main/scala/busymachines/core/notFoundAnomaly.scala
@@ -1,0 +1,104 @@
+package busymachines.core
+
+import busymachines.core.Anomaly.Parameters
+
+/**
+  *
+  * @author Lorand Szakacs, lsz@lorandszakacs.com, lorand.szakacs@busymachines.com
+  * @since 26 Dec 2017
+  *
+  */
+trait NotFoundAnomaly extends Anomaly with MeaningfulAnomalies.NotFound with Product with Serializable
+
+object NotFoundAnomaly extends AnomalyConstructors[NotFoundAnomaly] {
+  override def apply(id: AnomalyID): NotFoundAnomaly = NotFoundAnomalyImpl(id = id)
+
+  override def apply(message: String): NotFoundAnomaly = NotFoundAnomalyImpl(message = message)
+
+  override def apply(parameters: Parameters): NotFoundAnomaly = NotFoundAnomalyImpl(parameters = parameters)
+
+  override def apply(id: AnomalyID, message: String): NotFoundAnomaly =
+    NotFoundAnomalyImpl(id = id, message = message)
+
+  override def apply(id: AnomalyID, parameters: Parameters): NotFoundAnomaly =
+    NotFoundAnomalyImpl(id = id, parameters = parameters)
+
+  override def apply(message: String, parameters: Parameters): NotFoundAnomaly =
+    NotFoundAnomalyImpl(message = message, parameters = parameters)
+
+  override def apply(id: AnomalyID, message: String, parameters: Parameters): NotFoundAnomaly =
+    NotFoundAnomalyImpl(id = id, message = message, parameters = parameters)
+
+  override def apply(a: Anomaly): NotFoundAnomaly =
+    NotFoundAnomalyImpl(id = a.id, message = a.message, parameters = a.parameters)
+}
+
+private[core] final case class NotFoundAnomalyImpl(
+  override val id:         AnomalyID  = NotFoundAnomalyID,
+  override val message:    String     = MeaningfulAnomalies.`Not found`,
+  override val parameters: Parameters = Parameters.empty
+) extends NotFoundAnomaly {
+
+  override def asThrowable: Throwable = NotFoundFailureImpl(id, message, parameters)
+}
+
+//=============================================================================
+//=============================================================================
+//=============================================================================
+
+abstract class NotFoundFailure(
+  override val message: String,
+  causedBy:             Option[Throwable] = None,
+) extends AnomalousFailure(message, causedBy) with NotFoundAnomaly {
+  override def id: AnomalyID = NotFoundAnomalyID
+}
+
+object NotFoundFailure extends FailureConstructors[NotFoundFailure] {
+  override def apply(causedBy: Throwable): NotFoundFailure = NotFoundFailureImpl(causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID, message: String, causedBy: Throwable): NotFoundFailure =
+    NotFoundFailureImpl(id = id, message = message, causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID, parameters: Parameters, causedBy: Throwable): NotFoundFailure =
+    NotFoundFailureImpl(id = id, parameters = parameters, causedBy = Option(causedBy))
+
+  override def apply(message: String, parameters: Parameters, causedBy: Throwable): NotFoundFailure =
+    NotFoundFailureImpl(message = message, parameters = parameters, causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID, message: String, parameters: Parameters, causedBy: Throwable): NotFoundFailure =
+    NotFoundFailureImpl(id = id, message = message, parameters = parameters, causedBy = Option(causedBy))
+
+  override def apply(a: Anomaly, causedBy: Throwable): NotFoundFailure =
+    NotFoundFailureImpl(id = a.id, message = a.message, parameters = a.parameters, causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID): NotFoundFailure =
+    NotFoundFailureImpl(id = id)
+
+  override def apply(message: String): NotFoundFailure =
+    NotFoundFailureImpl(message = message)
+
+  override def apply(parameters: Parameters): NotFoundFailure =
+    NotFoundFailureImpl(parameters = parameters)
+
+  override def apply(id: AnomalyID, message: String): NotFoundFailure =
+    NotFoundFailureImpl(id = id, message = message)
+
+  override def apply(id: AnomalyID, parameters: Parameters): NotFoundFailure =
+    NotFoundFailureImpl(id = id, parameters = parameters)
+
+  override def apply(message: String, parameters: Parameters): NotFoundFailure =
+    NotFoundFailureImpl(message = message, parameters = parameters)
+
+  override def apply(id: AnomalyID, message: String, parameters: Parameters): NotFoundFailure =
+    NotFoundFailureImpl(id = id, message = message, parameters = parameters)
+
+  override def apply(a: Anomaly): NotFoundFailure =
+    NotFoundFailureImpl(id = a.id, message = a.message, parameters = a.parameters)
+}
+
+private[core] final case class NotFoundFailureImpl(
+  override val id:         AnomalyID         = NotFoundAnomalyID,
+  override val message:    String            = MeaningfulAnomalies.`Not found`,
+  override val parameters: Parameters        = Parameters.empty,
+  causedBy:                Option[Throwable] = None,
+) extends NotFoundFailure(message, causedBy)

--- a/core/src/main/scala/busymachines/core/notFoundAnomaly.scala
+++ b/core/src/main/scala/busymachines/core/notFoundAnomaly.scala
@@ -92,6 +92,7 @@ object NotFoundFailure extends FailureConstructors[NotFoundFailure] {
   override def apply(id: AnomalyID, message: String, parameters: Parameters): NotFoundFailure =
     NotFoundFailureImpl(id = id, message = message, parameters = parameters)
 
+  //we intentionally not pass a causedBy a.asThrowable. Not really meaningful in this case
   override def apply(a: Anomaly): NotFoundFailure =
     NotFoundFailureImpl(id = a.id, message = a.message, parameters = a.parameters)
 }

--- a/core/src/main/scala/busymachines/core/notFoundAnomaly.scala
+++ b/core/src/main/scala/busymachines/core/notFoundAnomaly.scala
@@ -53,7 +53,9 @@ abstract class NotFoundFailure(
   override def id: AnomalyID = NotFoundAnomalyID
 }
 
-object NotFoundFailure extends FailureConstructors[NotFoundFailure] {
+object NotFoundFailure
+    extends NotFoundFailure(MeaningfulAnomalies.`Not found`, None) with SingletonAnomalyProduct
+    with FailureConstructors[NotFoundFailure] {
   override def apply(causedBy: Throwable): NotFoundFailure = NotFoundFailureImpl(causedBy = Option(causedBy))
 
   override def apply(id: AnomalyID, message: String, causedBy: Throwable): NotFoundFailure =

--- a/core/src/main/scala/busymachines/core/notFoundAnomaly.scala
+++ b/core/src/main/scala/busymachines/core/notFoundAnomaly.scala
@@ -37,7 +37,7 @@ private[core] final case class NotFoundAnomalyImpl(
   override val id:         AnomalyID  = NotFoundAnomalyID,
   override val message:    String     = MeaningfulAnomalies.`Not found`,
   override val parameters: Parameters = Parameters.empty
-) extends NotFoundAnomaly {
+) extends NotFoundAnomaly with Product with Serializable {
 
   override def asThrowable: Throwable = NotFoundFailureImpl(id, message, parameters)
 }
@@ -49,7 +49,7 @@ private[core] final case class NotFoundAnomalyImpl(
 abstract class NotFoundFailure(
   override val message: String,
   causedBy:             Option[Throwable] = None,
-) extends AnomalousFailure(message, causedBy) with NotFoundAnomaly {
+) extends AnomalousFailure(message, causedBy) with NotFoundAnomaly with Product with Serializable {
   override def id: AnomalyID = NotFoundAnomalyID
 }
 
@@ -101,4 +101,4 @@ private[core] final case class NotFoundFailureImpl(
   override val message:    String            = MeaningfulAnomalies.`Not found`,
   override val parameters: Parameters        = Parameters.empty,
   causedBy:                Option[Throwable] = None,
-) extends NotFoundFailure(message, causedBy)
+) extends NotFoundFailure(message, causedBy) with Product with Serializable

--- a/core/src/main/scala/busymachines/core/package.scala
+++ b/core/src/main/scala/busymachines/core/package.scala
@@ -1,0 +1,20 @@
+package busymachines
+
+/**
+  *
+  * @author Lorand Szakacs, lsz@lorandszakacs.com, lorand.szakacs@busymachines.com
+  * @since 26 Dec 2017
+  *
+  */
+package object core {
+  type Parameter         = Anomaly.Param
+  type AnomalyParameters = Anomaly.Parameters
+
+  val AnomalyParameters: Anomaly.Parameters.type = Anomaly.Parameters
+
+  implicit final def anomalyParamValueStringWrapper(s: String): Parameter =
+    StringWrapper(s)
+
+  implicit final def anomalyParamValueSeqOfStringWrapper(ses: Seq[String]): Parameter =
+    SeqStringWrapper(ses.toVector)
+}

--- a/core/src/main/scala/busymachines/core/package.scala
+++ b/core/src/main/scala/busymachines/core/package.scala
@@ -7,14 +7,9 @@ package busymachines
   *
   */
 package object core {
-  type Parameter         = Anomaly.Param
-  type AnomalyParameters = Anomaly.Parameters
-
-  val AnomalyParameters: Anomaly.Parameters.type = Anomaly.Parameters
-
-  implicit final def anomalyParamValueStringWrapper(s: String): Parameter =
+  implicit final def anomalyParamValueStringWrapper(s: String): Anomaly.Parameter =
     StringWrapper(s)
 
-  implicit final def anomalyParamValueSeqOfStringWrapper(ses: Seq[String]): Parameter =
+  implicit final def anomalyParamValueSeqOfStringWrapper(ses: Seq[String]): Anomaly.Parameter =
     SeqStringWrapper(ses.toVector)
 }

--- a/core/src/main/scala/busymachines/core/unauthorizedAnomaly.scala
+++ b/core/src/main/scala/busymachines/core/unauthorizedAnomaly.scala
@@ -94,6 +94,9 @@ object UnauthorizedFailure extends FailureConstructors[UnauthorizedFailure] {
 
   override def apply(a: Anomaly): UnauthorizedFailure =
     UnauthorizedFailureImpl(id = a.id, message = a.message, parameters = a.parameters)
+
+  override def apply(message: String, causedBy: Throwable): UnauthorizedFailure =
+    UnauthorizedFailureImpl(message = message, causedBy = Option(causedBy))
 }
 
 private[core] final case class UnauthorizedFailureImpl(

--- a/core/src/main/scala/busymachines/core/unauthorizedAnomaly.scala
+++ b/core/src/main/scala/busymachines/core/unauthorizedAnomaly.scala
@@ -1,0 +1,104 @@
+package busymachines.core
+
+import busymachines.core.Anomaly.Parameters
+
+/**
+  *
+  * @author Lorand Szakacs, lsz@lorandszakacs.com, lorand.szakacs@busymachines.com
+  * @since 26 Dec 2017
+  *
+  */
+trait UnauthorizedAnomaly extends Anomaly with MeaningfulAnomalies.Unauthorized with Product with Serializable
+
+object UnauthorizedAnomaly extends AnomalyConstructors[UnauthorizedAnomaly] {
+  override def apply(id: AnomalyID): UnauthorizedAnomaly = UnauthorizedAnomalyImpl(id = id)
+
+  override def apply(message: String): UnauthorizedAnomaly = UnauthorizedAnomalyImpl(message = message)
+
+  override def apply(parameters: Parameters): UnauthorizedAnomaly = UnauthorizedAnomalyImpl(parameters = parameters)
+
+  override def apply(id: AnomalyID, message: String): UnauthorizedAnomaly =
+    UnauthorizedAnomalyImpl(id = id, message = message)
+
+  override def apply(id: AnomalyID, parameters: Parameters): UnauthorizedAnomaly =
+    UnauthorizedAnomalyImpl(id = id, parameters = parameters)
+
+  override def apply(message: String, parameters: Parameters): UnauthorizedAnomaly =
+    UnauthorizedAnomalyImpl(message = message, parameters = parameters)
+
+  override def apply(id: AnomalyID, message: String, parameters: Parameters): UnauthorizedAnomaly =
+    UnauthorizedAnomalyImpl(id = id, message = message, parameters = parameters)
+
+  override def apply(a: Anomaly): UnauthorizedAnomaly =
+    UnauthorizedAnomalyImpl(id = a.id, message = a.message, parameters = a.parameters)
+}
+
+private[core] final case class UnauthorizedAnomalyImpl(
+  override val id:         AnomalyID  = UnauthorizedAnomalyID,
+  override val message:    String     = MeaningfulAnomalies.`Unauthorized`,
+  override val parameters: Parameters = Parameters.empty
+) extends UnauthorizedAnomaly {
+
+  override def asThrowable: Throwable = UnauthorizedFailureImpl(id, message, parameters)
+}
+
+//=============================================================================
+//=============================================================================
+//=============================================================================
+
+abstract class UnauthorizedFailure(
+  override val message: String,
+  causedBy:             Option[Throwable] = None,
+) extends AnomalousFailure(message, causedBy) with UnauthorizedAnomaly {
+  override def id: AnomalyID = UnauthorizedAnomalyID
+}
+
+object UnauthorizedFailure extends FailureConstructors[UnauthorizedFailure] {
+  override def apply(causedBy: Throwable): UnauthorizedFailure = UnauthorizedFailureImpl(causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID, message: String, causedBy: Throwable): UnauthorizedFailure =
+    UnauthorizedFailureImpl(id = id, message = message, causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID, parameters: Parameters, causedBy: Throwable): UnauthorizedFailure =
+    UnauthorizedFailureImpl(id = id, parameters = parameters, causedBy = Option(causedBy))
+
+  override def apply(message: String, parameters: Parameters, causedBy: Throwable): UnauthorizedFailure =
+    UnauthorizedFailureImpl(message = message, parameters = parameters, causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID, message: String, parameters: Parameters, causedBy: Throwable): UnauthorizedFailure =
+    UnauthorizedFailureImpl(id = id, message = message, parameters = parameters, causedBy = Option(causedBy))
+
+  override def apply(a: Anomaly, causedBy: Throwable): UnauthorizedFailure =
+    UnauthorizedFailureImpl(id = a.id, message = a.message, parameters = a.parameters, causedBy = Option(causedBy))
+
+  override def apply(id: AnomalyID): UnauthorizedFailure =
+    UnauthorizedFailureImpl(id = id)
+
+  override def apply(message: String): UnauthorizedFailure =
+    UnauthorizedFailureImpl(message = message)
+
+  override def apply(parameters: Parameters): UnauthorizedFailure =
+    UnauthorizedFailureImpl(parameters = parameters)
+
+  override def apply(id: AnomalyID, message: String): UnauthorizedFailure =
+    UnauthorizedFailureImpl(id = id, message = message)
+
+  override def apply(id: AnomalyID, parameters: Parameters): UnauthorizedFailure =
+    UnauthorizedFailureImpl(id = id, parameters = parameters)
+
+  override def apply(message: String, parameters: Parameters): UnauthorizedFailure =
+    UnauthorizedFailureImpl(message = message, parameters = parameters)
+
+  override def apply(id: AnomalyID, message: String, parameters: Parameters): UnauthorizedFailure =
+    UnauthorizedFailureImpl(id = id, message = message, parameters = parameters)
+
+  override def apply(a: Anomaly): UnauthorizedFailure =
+    UnauthorizedFailureImpl(id = a.id, message = a.message, parameters = a.parameters)
+}
+
+private[core] final case class UnauthorizedFailureImpl(
+  override val id:         AnomalyID         = UnauthorizedAnomalyID,
+  override val message:    String            = MeaningfulAnomalies.`Unauthorized`,
+  override val parameters: Parameters        = Parameters.empty,
+  causedBy:                Option[Throwable] = None,
+) extends UnauthorizedFailure(message, causedBy)

--- a/core/src/main/scala/busymachines/core/unauthorizedAnomaly.scala
+++ b/core/src/main/scala/busymachines/core/unauthorizedAnomaly.scala
@@ -53,7 +53,9 @@ abstract class UnauthorizedFailure(
   override def id: AnomalyID = UnauthorizedAnomalyID
 }
 
-object UnauthorizedFailure extends FailureConstructors[UnauthorizedFailure] {
+object UnauthorizedFailure extends
+  UnauthorizedFailure(MeaningfulAnomalies.`Unauthorized`, None) with SingletonAnomalyProduct with
+  FailureConstructors[UnauthorizedFailure] {
   override def apply(causedBy: Throwable): UnauthorizedFailure = UnauthorizedFailureImpl(causedBy = Option(causedBy))
 
   override def apply(id: AnomalyID, message: String, causedBy: Throwable): UnauthorizedFailure =

--- a/core/src/main/scala/busymachines/core/unauthorizedAnomaly.scala
+++ b/core/src/main/scala/busymachines/core/unauthorizedAnomaly.scala
@@ -37,7 +37,7 @@ private[core] final case class UnauthorizedAnomalyImpl(
   override val id:         AnomalyID  = UnauthorizedAnomalyID,
   override val message:    String     = MeaningfulAnomalies.`Unauthorized`,
   override val parameters: Parameters = Parameters.empty
-) extends UnauthorizedAnomaly {
+) extends UnauthorizedAnomaly with Product with Serializable {
 
   override def asThrowable: Throwable = UnauthorizedFailureImpl(id, message, parameters)
 }
@@ -49,7 +49,7 @@ private[core] final case class UnauthorizedAnomalyImpl(
 abstract class UnauthorizedFailure(
   override val message: String,
   causedBy:             Option[Throwable] = None,
-) extends AnomalousFailure(message, causedBy) with UnauthorizedAnomaly {
+) extends AnomalousFailure(message, causedBy) with UnauthorizedAnomaly with Product with Serializable {
   override def id: AnomalyID = UnauthorizedAnomalyID
 }
 
@@ -101,4 +101,4 @@ private[core] final case class UnauthorizedFailureImpl(
   override val message:    String            = MeaningfulAnomalies.`Unauthorized`,
   override val parameters: Parameters        = Parameters.empty,
   causedBy:                Option[Throwable] = None,
-) extends UnauthorizedFailure(message, causedBy)
+) extends UnauthorizedFailure(message, causedBy) with Product with Serializable

--- a/core/src/test/scala/busymachines/core/UnionTypeWorkaroundTest.scala
+++ b/core/src/test/scala/busymachines/core/UnionTypeWorkaroundTest.scala
@@ -1,6 +1,5 @@
-package busymachines.core.exceptions
+package busymachines.core
 
-import busymachines.core.exceptions.FailureMessage.Parameters
 import org.scalatest.FlatSpec
 
 /**
@@ -11,15 +10,17 @@ import org.scalatest.FlatSpec
   */
 class UnionTypeWorkaroundTest extends FlatSpec {
 
-  behavior of "Failures"
+  behavior of "Anomalies"
 
   it should "... apply implicit conversions as a workaround to union types" in {
     assertCompiles {
       """
         |
+        |import busymachines.core._
+        |
         |object RevolutionaryDomainFailures {
         |
-        |  case object CannotBeDone extends FailureID {
+        |  case object CannotBeDone extends AnomalyID {
         |    val name = "rd_001"
         |  }
         |
@@ -28,9 +29,9 @@ class UnionTypeWorkaroundTest extends FlatSpec {
         |case class SolutionNotFoundFailure(problem: String, attempts: List[String]) extends NotFoundFailure(
         |  s"Solution to problem $problem not found."
         |) {
-        |  override def id: FailureID = RevolutionaryDomainFailures.CannotBeDone
+        |  override def id: AnomalyID = RevolutionaryDomainFailures.CannotBeDone
         |
-        |  override def parameters: Parameters = Map(
+        |  override def parameters: Anomaly.Parameters = Anomaly.Parameters(
         |    "problem" -> problem,
         |    "attempts" -> attempts
         |  )

--- a/json-spray/README.md
+++ b/json-spray/README.md
@@ -4,8 +4,8 @@
 
 _*DO NOT DEPEND ON BOTH THIS MODULE AND `json`. They share the same packages. It will end badly, chose one or the other. THIS MODULE WILL RECEIVE WAY LESS ATTENTION THAN THE OTHERS, AND HAS A HIGH CHANCE OF BEING DROPPED*_
 
-Current version is `0.2.0-RC7`. SBT module id:
-`"com.busymachines" %% "busymachines-commons-json-spray" % "0.2.0-RC7"`
+Current version is `0.2.0-RC8`. SBT module id:
+`"com.busymachines" %% "busymachines-commons-json-spray" % "0.2.0-RC8"`
 
 You should really, really use the [`json`](../json/README.md) module instead. This one is simply a legacy implementation for supporting the now defunct `spray-json`.
 

--- a/json-spray/src/main/scala/busymachines/json/CoreJsonConstants.scala
+++ b/json-spray/src/main/scala/busymachines/json/CoreJsonConstants.scala
@@ -1,0 +1,14 @@
+package busymachines.json
+
+/**
+  *
+  * @author Lorand Szakacs, lsz@lorandszakacs.com, lorand.szakacs@busymachines.com
+  * @since 26 Dec 2017
+  *
+  */
+private[json] object CoreJsonConstants {
+  private[json] val id:         String = "id"
+  private[json] val message:    String = "message"
+  private[json] val messages:   String = "messages"
+  private[json] val parameters: String = "parameters"
+}

--- a/json-spray/src/main/scala/busymachines/json/anomalyJsonCodec.scala
+++ b/json-spray/src/main/scala/busymachines/json/anomalyJsonCodec.scala
@@ -1,0 +1,97 @@
+package busymachines.json
+
+import busymachines.core._
+import spray.json._
+
+import scala.collection.immutable
+import scala.util.control.NonFatal
+import scala.util._
+
+/**
+  *
+  * @author Lorand Szakacs, lsz@lorandszakacs.com, lorand.szakacs@busymachines.com
+  * @since 26 Dec 2017
+  *
+  */
+object AnomalyJsonCodec extends AnomalyJsonCodec
+
+trait AnomalyJsonCodec {
+
+  import DefaultJsonProtocol._
+
+  private implicit final val AnomalyIDCodec: ValueCodec[AnomalyID] = new ValueCodec[AnomalyID] {
+    override def read(json: Json): AnomalyID = AnomalyID(json.convertTo[String])
+
+    override def write(obj: AnomalyID): Json = JsString(obj.name)
+  }
+
+  private implicit final val StringOrSeqCodec: Codec[Anomaly.Parameter] = new Codec[Anomaly.Parameter] {
+    override def write(a: Anomaly.Parameter): Json = {
+      a match {
+        case StringWrapper(s) => JsString(s)
+        case SeqStringWrapper(ses) =>
+          JsArray(ses.map(s => implicitly[JsonFormat[String]].write(s)).toVector)
+      }
+    }
+
+    override def read(c: Json): Anomaly.Parameter = {
+      Try(c.convertTo[immutable.Seq[String]])
+        .map((s: immutable.Seq[String]) => Anomaly.ParamValue(s))
+        .recoverWith {
+          case NonFatal(_) => Try(c.convertTo[String]).map(Anomaly.ParamValue.apply)
+        }
+        .get
+    }
+  }
+
+  final implicit val AnomalyCodec: Codec[Anomaly] = new Codec[Anomaly] {
+    private val jsonCodec = jsonFormat3(AnomalyRepr)
+
+    override def read(c: Json): Anomaly = {
+      val rpr = jsonCodec.read(c)
+      Anomaly(rpr.id, rpr.message, rpr.parameters.getOrElse(Anomaly.Parameters.empty))
+    }
+
+    override def write(a: Anomaly): Json = {
+      JsonObject(
+        CoreJsonConstants.id         -> a.id.toJson,
+        CoreJsonConstants.message    -> a.message.toJson,
+        CoreJsonConstants.parameters -> a.parameters.toJson
+      )
+    }
+  }
+
+  final implicit val AnomaliesCodec: Codec[Anomalies] = new Codec[Anomalies] {
+    private val jsonCodec: Codec[AnomaliesRepr] = jsonFormat3(AnomaliesRepr)
+
+    override def write(a: Anomalies): Json = {
+      JsonObject(
+        CoreJsonConstants.id       -> a.id.toJson,
+        CoreJsonConstants.message  -> a.message.toJson,
+        CoreJsonConstants.messages -> a.messages.toJson
+      )
+    }
+
+    override def read(c: Json): Anomalies = {
+      val repr = jsonCodec.read(c)
+      Anomalies(
+        id      = repr.id,
+        message = repr.message,
+        msg     = repr.messages.headOption.getOrElse(deserializationError("Needs to have at least on messages")),
+        repr.messages.tail: _*
+      )
+    }
+  }
+}
+
+private[json] case class AnomalyRepr(
+  id:         AnomalyID,
+  message:    String,
+  parameters: Option[Anomaly.Parameters]
+)
+
+private[json] case class AnomaliesRepr(
+  id:       AnomalyID,
+  message:  String,
+  messages: immutable.Seq[Anomaly]
+)

--- a/json-spray/src/main/scala/busymachines/json/anomalyJsonCodec.scala
+++ b/json-spray/src/main/scala/busymachines/json/anomalyJsonCodec.scala
@@ -36,9 +36,9 @@ trait AnomalyJsonCodec {
 
     override def read(c: Json): Anomaly.Parameter = {
       Try(c.convertTo[immutable.Seq[String]])
-        .map((s: immutable.Seq[String]) => Anomaly.ParamValue(s))
+        .map((s: immutable.Seq[String]) => Anomaly.Parameter(s))
         .recoverWith {
-          case NonFatal(_) => Try(c.convertTo[String]).map(Anomaly.ParamValue.apply)
+          case NonFatal(_) => Try(c.convertTo[String]).map(Anomaly.Parameter)
         }
         .get
     }

--- a/json-spray/src/main/scala/busymachines/json/failureMessageJsonCodec.scala
+++ b/json-spray/src/main/scala/busymachines/json/failureMessageJsonCodec.scala
@@ -85,12 +85,7 @@ trait FailureMessageJsonCodec {
   }
 }
 
-private[json] object CoreJsonConstants {
-  private[json] val id:         String = "id"
-  private[json] val message:    String = "message"
-  private[json] val messages:   String = "messages"
-  private[json] val parameters: String = "parameters"
-}
+
 
 private[json] case class FailureMessageRepr(
   id:         FailureID,

--- a/json-spray/src/main/scala/busymachines/json/utilsJson.scala
+++ b/json-spray/src/main/scala/busymachines/json/utilsJson.scala
@@ -41,7 +41,7 @@ final case class JsonDecodingFailure(msg: String) extends InvalidInputFailure(ms
 object JsonParsing {
 
   def unsafeParseString(input: String): Json = {
-    Try[Json](spray.json.pimpString(input).parseJson).recoverWith {
+    Try[Json](spray.json.JsonParser(input)).recoverWith {
       case NonFatal(e) =>
         scala.util.Failure(busymachines.json.JsonParsingFailure(e.getMessage))
     }.get

--- a/json-spray/src/main/scala/busymachines/json/utilsJson.scala
+++ b/json-spray/src/main/scala/busymachines/json/utilsJson.scala
@@ -1,6 +1,6 @@
 package busymachines.json
 
-import busymachines.core.exceptions._
+import busymachines.core._
 import spray.json.{CompactPrinter, JsonPrinter, PrettyPrinter}
 
 import scala.util.Try
@@ -30,7 +30,7 @@ object JsonDecoding {
 }
 
 final case class JsonDecodingFailure(msg: String) extends InvalidInputFailure(msg) {
-  override def id: FailureID = JsonFailureIDs.JsonDecodingFailureID
+  override def id: AnomalyID = JsonAnomalyIDs.JsonDecodingAnomalyID
 }
 
 /**
@@ -59,19 +59,19 @@ object PrettyJson {
 }
 
 final case class JsonParsingFailure(msg: String) extends InvalidInputFailure(msg) {
-  override def id: FailureID = JsonFailureIDs.JsonParsingFailureID
+  override def id: AnomalyID = JsonAnomalyIDs.JsonParsingAnomalyID
 }
 
 /**
   *
   */
-object JsonFailureIDs {
+object JsonAnomalyIDs {
 
-  case object JsonParsingFailureID extends FailureID {
+  case object JsonParsingAnomalyID extends AnomalyID {
     override def name: String = "json_01"
   }
 
-  case object JsonDecodingFailureID extends FailureID {
+  case object JsonDecodingAnomalyID extends AnomalyID {
     override def name: String = "json_02"
   }
 

--- a/json-spray/src/test/scala/busymachines/json_spray_test/AnomalyJsonTest.scala
+++ b/json-spray/src/test/scala/busymachines/json_spray_test/AnomalyJsonTest.scala
@@ -1,6 +1,6 @@
 package busymachines.json_spray_test
 
-import busymachines.core.exceptions._
+import busymachines.core._
 import org.scalatest.{FlatSpec, Matchers}
 
 /**
@@ -9,19 +9,18 @@ import org.scalatest.{FlatSpec, Matchers}
   * @since 10 Aug 2017
   *
   */
-@scala.deprecated("Will be removed in 0.3.0", "0.2.0")
-class FailureMessageJsonTest extends FlatSpec with Matchers {
+class AnomalyJsonTest extends FlatSpec with Matchers {
 
   import busymachines.json._
+  import AnomalyJsonCodec._
   import syntax._
-  import FailureMessageJsonCodec._
 
-  behavior of "... serializing simple FailureMessages"
+  behavior of "... serializing simple Anomalies"
 
   it should "... encode a NotFoundFailure" in {
-    val failure: FailureMessage = NotFoundFailure(
+    val failure: Anomaly = NotFoundFailure(
       "test message",
-      FailureMessage.Parameters(
+      Anomaly.Parameters(
         "one" -> "one",
         "two" -> List("one", "two")
       )
@@ -41,16 +40,16 @@ class FailureMessageJsonTest extends FlatSpec with Matchers {
           |""".stripMargin.trim
     )
 
-    val read = rawJson.unsafeDecodeAs[FailureMessage]
+    val read = rawJson.unsafeDecodeAs[Anomaly]
     assert(read.id.name == failure.id.name,       "id")
     assert(read.message == failure.message,       "message")
     assert(read.parameters == failure.parameters, "parameters")
   }
 
   it should "... encode a UnauthorizedFailure" in {
-    val failure: FailureMessage = UnauthorizedFailure(
+    val failure: Anomaly = UnauthorizedFailure(
       "test message",
-      FailureMessage.Parameters(
+      Anomaly.Parameters(
         "one" -> "one",
         "two" -> List("one", "two")
       )
@@ -70,16 +69,16 @@ class FailureMessageJsonTest extends FlatSpec with Matchers {
           |""".stripMargin.trim
     )
 
-    val read = rawJson.unsafeDecodeAs[FailureMessage]
+    val read = rawJson.unsafeDecodeAs[Anomaly]
     assert(read.id.name == failure.id.name,       "id")
     assert(read.message == failure.message,       "message")
     assert(read.parameters == failure.parameters, "parameters")
   }
 
   it should "... encode a ForbiddenFailure" in {
-    val failure: FailureMessage = ForbiddenFailure(
+    val failure: Anomaly = ForbiddenFailure(
       "test message",
-      FailureMessage.Parameters(
+      Anomaly.Parameters(
         "one" -> "one",
         "two" -> List("one", "two")
       )
@@ -99,16 +98,16 @@ class FailureMessageJsonTest extends FlatSpec with Matchers {
           |""".stripMargin.trim
     )
 
-    val read = rawJson.unsafeDecodeAs[FailureMessage]
+    val read = rawJson.unsafeDecodeAs[Anomaly]
     assert(read.id.name == failure.id.name,       "id")
     assert(read.message == failure.message,       "message")
     assert(read.parameters == failure.parameters, "parameters")
   }
 
   it should "... encode a DeniedFailure" in {
-    val failure: FailureMessage = DeniedFailure(
+    val failure: Anomaly = DeniedFailure(
       "test message",
-      FailureMessage.Parameters(
+      Anomaly.Parameters(
         "one" -> "one",
         "two" -> List("one", "two")
       )
@@ -128,16 +127,16 @@ class FailureMessageJsonTest extends FlatSpec with Matchers {
           |""".stripMargin.trim
     )
 
-    val read = rawJson.unsafeDecodeAs[FailureMessage]
+    val read = rawJson.unsafeDecodeAs[Anomaly]
     assert(read.id.name == failure.id.name,       "id")
     assert(read.message == failure.message,       "message")
     assert(read.parameters == failure.parameters, "parameters")
   }
 
   it should "... encode a InvalidInputFailure" in {
-    val failure: FailureMessage = InvalidInputFailure(
+    val failure: Anomaly = InvalidInputFailure(
       "test message",
-      FailureMessage.Parameters(
+      Anomaly.Parameters(
         "one" -> "one",
         "two" -> List("one", "two")
       )
@@ -157,16 +156,16 @@ class FailureMessageJsonTest extends FlatSpec with Matchers {
           |""".stripMargin.trim
     )
 
-    val read = rawJson.unsafeDecodeAs[FailureMessage]
+    val read = rawJson.unsafeDecodeAs[Anomaly]
     assert(read.id.name == failure.id.name,       "id")
     assert(read.message == failure.message,       "message")
     assert(read.parameters == failure.parameters, "parameters")
   }
 
   it should "... encode a ConflictFailure" in {
-    val failure: FailureMessage = ConflictFailure(
+    val failure: Anomaly = ConflictFailure(
       "test message",
-      FailureMessage.Parameters(
+      Anomaly.Parameters(
         "one" -> "one",
         "two" -> List("one", "two")
       )
@@ -186,28 +185,28 @@ class FailureMessageJsonTest extends FlatSpec with Matchers {
           |""".stripMargin.trim
     )
 
-    val read = rawJson.unsafeDecodeAs[FailureMessage]
+    val read = rawJson.unsafeDecodeAs[Anomaly]
     assert(read.id.name == failure.id.name,       "id")
     assert(read.message == failure.message,       "message")
     assert(read.parameters == failure.parameters, "parameters")
   }
 
-  behavior of "... serializing composite FailureMessages"
+  behavior of "... serializing composite Anomalies"
 
   it should "... encode Failures" in {
-    val failure: FailureMessages = Failures(
-      FailureID("test"),
+    val failure: Anomalies = Anomalies(
+      AnomalyID("test"),
       "test message",
       NotFoundFailure(
         "one",
-        FailureMessage.Parameters(
+        Anomaly.Parameters(
           "3" -> "1",
           "4" -> List("1", "2")
         )
       ),
       NotFoundFailure(
         "two",
-        FailureMessage.Parameters(
+        Anomaly.Parameters(
           "5" -> "6",
           "6" -> List("6", "7")
         )
@@ -239,7 +238,7 @@ class FailureMessageJsonTest extends FlatSpec with Matchers {
           |""".stripMargin.trim
     )
 
-    val read = rawJson.unsafeDecodeAs[FailureMessage]
+    val read = rawJson.unsafeDecodeAs[Anomaly]
     assert(read.id.name == failure.id.name,       "id")
     assert(read.message == failure.message,       "message")
     assert(read.parameters == failure.parameters, "parameters")
@@ -255,6 +254,6 @@ class FailureMessageJsonTest extends FlatSpec with Matchers {
         |}
         |""".stripMargin.trim
 
-    the[JsonDecodingFailure] thrownBy rawJson.unsafeDecodeAs[FailureMessages]
+    the[JsonDecodingFailure] thrownBy rawJson.unsafeDecodeAs[Anomalies]
   }
 }

--- a/json/README.md
+++ b/json/README.md
@@ -271,7 +271,7 @@ trait DefaultTypeDiscriminatorConfig {
 
 ## provided decoders
 
-The object/trait `busymachines.json.FailureMessageJsonCodec` contains all encoders necessary for dealing with the exceptions from core.
+The object/trait `busymachines.json.AnomalyJsonCodec` contains all encoders necessary for dealing with the exceptions from core.
 
 ## tests
 

--- a/json/README.md
+++ b/json/README.md
@@ -2,8 +2,8 @@
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.busymachines/busymachines-commons-json_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.busymachines/busymachines-commons-json_2.12)
 
-Current version is `0.2.0-RC7`. SBT module id:
-`"com.busymachines" %% "busymachines-commons-json" % "0.2.0-RC7"`
+Current version is `0.2.0-RC8`. SBT module id:
+`"com.busymachines" %% "busymachines-commons-json" % "0.2.0-RC8"`
 
 ## How it works
 This module is a thin layer over [circe](https://circe.github.io/circe/), additionally, it depends on [shapeless](https://github.com/milessabin/shapeless). The latter being the mechanism through which `autoderive` and `derive` derivation can be made to work.

--- a/json/src/main/scala/busymachines/json/AnomalyJsonCodec.scala
+++ b/json/src/main/scala/busymachines/json/AnomalyJsonCodec.scala
@@ -1,0 +1,135 @@
+package busymachines.json
+
+import busymachines.core._
+import io.circe.Decoder.Result
+import io.circe.DecodingFailure
+
+/**
+  *
+  * @author Lorand Szakacs, lsz@lorandszakacs.com, lorand.szakacs@busymachines.com
+  * @since 26 Dec 2017
+  *
+  */
+object AnomalyJsonCodec extends AnomalyJsonCodec
+
+trait AnomalyJsonCodec {
+
+  private implicit final val AnomalyIDCodec: Codec[AnomalyID] = new Codec[AnomalyID] {
+    override def apply(c: HCursor): Result[AnomalyID] = {
+      c.as[String].right.map(AnomalyID.apply)
+    }
+
+    override def apply(a: AnomalyID): Json = Json.fromString(a.name)
+  }
+
+  private implicit final val StringOrSeqCodec: Codec[Anomaly.Parameter] = new Codec[Anomaly.Parameter] {
+    override def apply(a: Anomaly.Parameter): Json = {
+      a match {
+        case StringWrapper(s)      => Json.fromString(s)
+        case SeqStringWrapper(ses) => Json.fromValues(ses.map(Json.fromString))
+      }
+    }
+
+    override def apply(c: HCursor): io.circe.Decoder.Result[Anomaly.Parameter] = {
+      val sa: Result[String] = c.as[String]
+      if (sa.isRight) {
+        sa.right.map(Anomaly.ParamValue.apply)
+      }
+      else {
+        c.as[List[String]].right.map(Anomaly.ParamValue.apply)
+      }
+    }
+  }
+
+  private implicit final val AnomalyParamsCodec: Codec[Anomaly.Parameters] =
+    new Codec[Anomaly.Parameters] {
+      override def apply(c: HCursor): Result[Anomaly.Parameters] = {
+        val jsonObj = c.as[JsonObject]
+        val m       = jsonObj.right.map(_.toMap)
+        val m2: Either[DecodingFailure, Either[DecodingFailure, Anomaly.Parameters]] = m.right.map {
+          (e: Map[String, Json]) =>
+            val potentialFailures = e.map { p =>
+              p._2.as[Anomaly.Parameter].right.map(s => (p._1, s))
+            }.toList
+
+            if (potentialFailures.nonEmpty) {
+              val first: Either[DecodingFailure, List[(String, Anomaly.Parameter)]] =
+                potentialFailures.head.right.map(e => List(e))
+              val rest = potentialFailures.tail
+              val r: Either[DecodingFailure, List[(String, Anomaly.Parameter)]] = rest.foldRight(first) { (v, acc) =>
+                for {
+                  prevAcc <- acc.right
+                  newVal  <- v.right
+                } yield prevAcc :+ newVal
+              }
+              r.right.map(l => Anomaly.Parameters.apply(l: _*))
+            }
+            else {
+              Right[DecodingFailure, Anomaly.Parameters](Anomaly.Parameters.empty)
+            }
+        }
+        m2.right.flatMap(x => identity(x))
+      }
+
+      override def apply(a: Anomaly.Parameters): Json = {
+        if (a.isEmpty) {
+          Json.fromJsonObject(JsonObject.empty)
+        }
+        else {
+          val parametersJson = a.map { p =>
+            (p._1, StringOrSeqCodec(p._2))
+          }
+          io.circe.Json.fromFields(parametersJson)
+        }
+      }
+    }
+
+  final implicit val AnomalyCodec: Codec[Anomaly] = new Codec[Anomaly] {
+    override def apply(c: HCursor): io.circe.Decoder.Result[Anomaly] = {
+      for {
+        id     <- c.get[AnomalyID](CoreJsonConstants.id)
+        msg    <- c.get[String](CoreJsonConstants.message)
+        params <- c.getOrElse[Anomaly.Parameters](CoreJsonConstants.parameters)(Anomaly.Parameters.empty)
+      } yield Anomaly(id, msg, params)
+    }
+
+    override def apply(a: Anomaly): Json = {
+      val id      = AnomalyIDCodec(a.id)
+      val message = Json.fromString(a.message)
+      if (a.parameters.isEmpty) {
+        Json.obj(
+          CoreJsonConstants.id      -> id,
+          CoreJsonConstants.message -> message
+        )
+      }
+      else {
+        val params = AnomalyParamsCodec(a.parameters)
+        Json.obj(
+          CoreJsonConstants.id         -> id,
+          CoreJsonConstants.message    -> message,
+          CoreJsonConstants.parameters -> params
+        )
+      }
+    }
+  }
+
+  final implicit val AnomaliesCodec: Codec[Anomalies] = new Codec[Anomalies] {
+    override def apply(a: Anomalies): Json = {
+      val fm          = AnomalyCodec.apply(a)
+      val arr         = a.messages.map(AnomalyCodec.apply)
+      val messagesObj = Json.obj(CoreJsonConstants.messages -> Json.arr(arr: _*))
+      messagesObj.deepMerge(fm)
+    }
+
+    override def apply(c: HCursor): Result[Anomalies] = {
+      for {
+        fm   <- c.as[Anomaly].right
+        msgs <- c.get[Seq[Anomaly]](CoreJsonConstants.messages).right
+        _ <- (if (msgs.isEmpty)
+                Left(DecodingFailure("Anomalies.message needs to be non empty array", c.history))
+              else
+                Right.apply(())).right
+      } yield Anomalies.apply(fm.id, fm.message, msgs.head, msgs.tail: _*)
+    }
+  }
+}

--- a/json/src/main/scala/busymachines/json/AnomalyJsonCodec.scala
+++ b/json/src/main/scala/busymachines/json/AnomalyJsonCodec.scala
@@ -33,10 +33,10 @@ trait AnomalyJsonCodec {
     override def apply(c: HCursor): io.circe.Decoder.Result[Anomaly.Parameter] = {
       val sa: Result[String] = c.as[String]
       if (sa.isRight) {
-        sa.right.map(Anomaly.ParamValue.apply)
+        sa.right.map(Anomaly.Parameter)
       }
       else {
-        c.as[List[String]].right.map(Anomaly.ParamValue.apply)
+        c.as[List[String]].right.map(Anomaly.Parameter)
       }
     }
   }
@@ -62,7 +62,7 @@ trait AnomalyJsonCodec {
                   newVal  <- v.right
                 } yield prevAcc :+ newVal
               }
-              r.right.map(l => Anomaly.Parameters.apply(l: _*))
+              r.right.map(l => Anomaly.Parameters(l: _*))
             }
             else {
               Right[DecodingFailure, Anomaly.Parameters](Anomaly.Parameters.empty)

--- a/json/src/main/scala/busymachines/json/CoreJsonConstants.scala
+++ b/json/src/main/scala/busymachines/json/CoreJsonConstants.scala
@@ -1,0 +1,14 @@
+package busymachines.json
+
+/**
+  *
+  * @author Lorand Szakacs, lsz@lorandszakacs.com, lorand.szakacs@busymachines.com
+  * @since 26 Dec 2017
+  *
+  */
+private[json] object CoreJsonConstants {
+  private[json] val id:         String = "id"
+  private[json] val message:    String = "message"
+  private[json] val messages:   String = "messages"
+  private[json] val parameters: String = "parameters"
+}

--- a/json/src/main/scala/busymachines/json/failureMessageJsonCodec.scala
+++ b/json/src/main/scala/busymachines/json/failureMessageJsonCodec.scala
@@ -10,10 +10,13 @@ import io.circe.DecodingFailure
   * @since 10 Aug 2017
   *
   */
+@scala.deprecated("Will be removed in 0.3.0 — Use AnomalyJsonCodec", "0.2.0")
 object FailureMessageJsonCodec extends FailureMessageJsonCodec
 
+@scala.deprecated("Will be removed in 0.3.0 — Use AnomalyJsonCodec", "0.2.0")
 trait FailureMessageJsonCodec {
 
+  @scala.deprecated("Will be removed in 0.3.0 — Use AnomalyJsonCodec", "0.2.0")
   private implicit final val FailureIDCodec: Codec[FailureID] = new Codec[FailureID] {
     override def apply(c: HCursor): Result[FailureID] = {
       c.as[String].right.map(FailureID.apply)
@@ -22,6 +25,7 @@ trait FailureMessageJsonCodec {
     override def apply(a: FailureID): Json = Json.fromString(a.name)
   }
 
+  @scala.deprecated("Will be removed in 0.3.0 — Use AnomalyJsonCodec", "0.2.0")
   private implicit final val StringOrSeqCodec: Codec[FailureMessage.ParamValue] = new Codec[FailureMessage.ParamValue] {
     override def apply(a: FailureMessage.ParamValue): Json = {
       a match {
@@ -41,6 +45,7 @@ trait FailureMessageJsonCodec {
     }
   }
 
+  @scala.deprecated("Will be removed in 0.3.0 — Use AnomalyJsonCodec", "0.2.0")
   private implicit final val FailureMessageParamsCodec: Codec[FailureMessage.Parameters] =
     new Codec[FailureMessage.Parameters] {
       override def apply(c: HCursor): Result[FailureMessage.Parameters] = {
@@ -85,6 +90,7 @@ trait FailureMessageJsonCodec {
       }
     }
 
+  @scala.deprecated("Will be removed in 0.3.0 — Use AnomalyJsonCodec", "0.2.0")
   final implicit val failureMessageCodec: Codec[FailureMessage] = new Codec[FailureMessage] {
     override def apply(c: HCursor): io.circe.Decoder.Result[FailureMessage] = {
       for {
@@ -114,6 +120,7 @@ trait FailureMessageJsonCodec {
     }
   }
 
+  @scala.deprecated("Will be removed in 0.3.0 — Use AnomalyJsonCodec", "0.2.0")
   final implicit val failureMessagesCodec: Codec[FailureMessages] = new Codec[FailureMessages] {
     override def apply(a: FailureMessages): Json = {
       val fm          = failureMessageCodec.apply(a)
@@ -127,17 +134,10 @@ trait FailureMessageJsonCodec {
         fm   <- c.as[FailureMessage].right
         msgs <- c.get[Seq[FailureMessage]](CoreJsonConstants.messages).right
         _ <- (if (msgs.isEmpty)
-                Left(DecodingFailure("FailureMessages.message needs to be non empty array", c.history))
-              else
-                Right.apply(())).right
+          Left(DecodingFailure("FailureMessages.message needs to be non empty array", c.history))
+        else
+          Right.apply(())).right
       } yield FailureMessages.apply(fm.id, fm.message, msgs.head, msgs.tail: _*)
     }
   }
-}
-
-private[json] object CoreJsonConstants {
-  private[json] val id:         String = "id"
-  private[json] val message:    String = "message"
-  private[json] val messages:   String = "messages"
-  private[json] val parameters: String = "parameters"
 }

--- a/json/src/main/scala/busymachines/json/package.scala
+++ b/json/src/main/scala/busymachines/json/package.scala
@@ -1,6 +1,6 @@
 package busymachines
 
-import busymachines.core.exceptions._
+import busymachines.core._
 
 /**
   * The reason we break the modularity of circe is rather pragmatic. The design philosophy of this
@@ -49,6 +49,22 @@ package object json extends DefaultTypeDiscriminatorConfig {
   type HCursor = io.circe.HCursor
   val HCursor: io.circe.HCursor.type = io.circe.HCursor
 
-  type JsonDecodingResult[A] = Either[FailureBase, A]
-  type JsonParsingResult     = Either[FailureBase, Json]
+  type JsonDecodingResult[A] = Either[Anomaly, A]
+  type JsonParsingResult     = Either[Anomaly, Json]
+
+  implicit class JsonDecodingResultOps[A](e: JsonDecodingResult[A]) {
+
+    def unsafeGet: A = e match {
+      case Left(value)  => throw value.asThrowable
+      case Right(value) => value
+    }
+  }
+
+  implicit class JsonParsingResultOps(e: JsonParsingResult) {
+
+    def unsafeGet: Json = e match {
+      case Left(value)  => throw value.asThrowable
+      case Right(value) => value
+    }
+  }
 }

--- a/json/src/main/scala/busymachines/json/utilsJson.scala
+++ b/json/src/main/scala/busymachines/json/utilsJson.scala
@@ -1,7 +1,7 @@
 package busymachines.json
 
 import io.circe.parser._
-import busymachines.core.exceptions._
+import busymachines.core._
 import io.circe.Printer
 
 /**
@@ -23,16 +23,16 @@ object JsonDecoding {
   }
 
   def unsafeDecodeAs[A](json: Json)(implicit decoder: Decoder[A]): A = {
-    this.decodeAs[A](json)(decoder).toTry.get
+    this.decodeAs[A](json)(decoder).unsafeGet
   }
 
   def unsafeDecodeAs[A](json: String)(implicit decoder: Decoder[A]): A = {
-    JsonDecoding.decodeAs(json).toTry.get
+    JsonDecoding.decodeAs(json).unsafeGet
   }
 }
 
 final case class JsonDecodingFailure(msg: String) extends InvalidInputFailure(msg) {
-  override def id: FailureID = JsonFailureIDs.JsonDecodingFailureID
+  override def id: AnomalyID = JsonAnomalyIDs.JsonDecodingAnomalyID
 }
 
 /**
@@ -47,7 +47,7 @@ object JsonParsing {
   }
 
   def unsafeParseString(input: String): Json = {
-    JsonParsing.parseString(input).toTry.get
+    JsonParsing.parseString(input).unsafeGet
   }
 
 }
@@ -64,19 +64,19 @@ object PrettyJson {
 }
 
 final case class JsonParsingFailure(msg: String) extends InvalidInputFailure(msg) {
-  override def id: FailureID = JsonFailureIDs.JsonParsingFailureID
+  override def id: AnomalyID = JsonAnomalyIDs.JsonParsingAnomalyID
 }
 
 /**
   *
   */
-object JsonFailureIDs {
+object JsonAnomalyIDs {
 
-  case object JsonParsingFailureID extends FailureID {
+  case object JsonParsingAnomalyID extends AnomalyID {
     override def name: String = "json_01"
   }
 
-  case object JsonDecodingFailureID extends FailureID {
+  case object JsonDecodingAnomalyID extends AnomalyID {
     override def name: String = "json_02"
   }
 

--- a/json/src/test/scala/busymachines/json_test/AnomalyJsonTest.scala
+++ b/json/src/test/scala/busymachines/json_test/AnomalyJsonTest.scala
@@ -1,6 +1,6 @@
 package busymachines.json_test
 
-import busymachines.core.exceptions._
+import busymachines.core._
 import org.scalatest.FlatSpec
 
 /**
@@ -9,19 +9,18 @@ import org.scalatest.FlatSpec
   * @since 10 Aug 2017
   *
   */
-@scala.deprecated("Will be removed in 0.3.0", "0.2.0")
-class FailureMessageJsonTest extends FlatSpec {
+class AnomalyJsonTest extends FlatSpec {
 
   import busymachines.json._
+  import AnomalyJsonCodec._
   import syntax._
-  import FailureMessageJsonCodec._
 
-  behavior of "... serializing simple FailureMessages"
+  behavior of "... serializing simple Anomalies"
 
   it should "... encode a NotFoundFailure" in {
-    val failure: FailureMessage = NotFoundFailure(
+    val failure: Anomaly = NotFoundFailure(
       "test message",
-      FailureMessage.Parameters(
+      Anomaly.Parameters(
         "one" -> "one",
         "two" -> List("one", "two")
       )
@@ -44,16 +43,16 @@ class FailureMessageJsonTest extends FlatSpec {
           |""".stripMargin.trim
     )
 
-    val read = rawJson.unsafeDecodeAs[FailureMessage]
+    val read = rawJson.unsafeDecodeAs[Anomaly]
     assert(read.id.name == failure.id.name,       "id")
     assert(read.message == failure.message,       "message")
     assert(read.parameters == failure.parameters, "parameters")
   }
 
   it should "... encode a UnauthorizedFailure" in {
-    val failure: FailureMessage = UnauthorizedFailure(
+    val failure: Anomaly = UnauthorizedFailure(
       "test message",
-      FailureMessage.Parameters(
+      Anomaly.Parameters(
         "one" -> "one",
         "two" -> List("one", "two")
       )
@@ -76,16 +75,16 @@ class FailureMessageJsonTest extends FlatSpec {
           |""".stripMargin.trim
     )
 
-    val read = rawJson.unsafeDecodeAs[FailureMessage]
+    val read = rawJson.unsafeDecodeAs[Anomaly]
     assert(read.id.name == failure.id.name,       "id")
     assert(read.message == failure.message,       "message")
     assert(read.parameters == failure.parameters, "parameters")
   }
 
   it should "... encode a ForbiddenFailure" in {
-    val failure: FailureMessage = ForbiddenFailure(
+    val failure: Anomaly = ForbiddenFailure(
       "test message",
-      FailureMessage.Parameters(
+      Anomaly.Parameters(
         "one" -> "one",
         "two" -> List("one", "two")
       )
@@ -108,16 +107,16 @@ class FailureMessageJsonTest extends FlatSpec {
           |""".stripMargin.trim
     )
 
-    val read = rawJson.unsafeDecodeAs[FailureMessage]
+    val read = rawJson.unsafeDecodeAs[Anomaly]
     assert(read.id.name == failure.id.name,       "id")
     assert(read.message == failure.message,       "message")
     assert(read.parameters == failure.parameters, "parameters")
   }
 
   it should "... encode a DeniedFailure" in {
-    val failure: FailureMessage = DeniedFailure(
+    val failure: Anomaly = DeniedFailure(
       "test message",
-      FailureMessage.Parameters(
+      Anomaly.Parameters(
         "one" -> "one",
         "two" -> List("one", "two")
       )
@@ -140,16 +139,16 @@ class FailureMessageJsonTest extends FlatSpec {
           |""".stripMargin.trim
     )
 
-    val read = rawJson.unsafeDecodeAs[FailureMessage]
+    val read = rawJson.unsafeDecodeAs[Anomaly]
     assert(read.id.name == failure.id.name,       "id")
     assert(read.message == failure.message,       "message")
     assert(read.parameters == failure.parameters, "parameters")
   }
 
   it should "... encode a InvalidInputFailure" in {
-    val failure: FailureMessage = InvalidInputFailure(
+    val failure: Anomaly = InvalidInputFailure(
       "test message",
-      FailureMessage.Parameters(
+      Anomaly.Parameters(
         "one" -> "one",
         "two" -> List("one", "two")
       )
@@ -172,16 +171,16 @@ class FailureMessageJsonTest extends FlatSpec {
           |""".stripMargin.trim
     )
 
-    val read = rawJson.unsafeDecodeAs[FailureMessage]
+    val read = rawJson.unsafeDecodeAs[Anomaly]
     assert(read.id.name == failure.id.name,       "id")
     assert(read.message == failure.message,       "message")
     assert(read.parameters == failure.parameters, "parameters")
   }
 
   it should "... encode a ConflictFailure" in {
-    val failure: FailureMessage = ConflictFailure(
+    val failure: Anomaly = ConflictFailure(
       "test message",
-      FailureMessage.Parameters(
+      Anomaly.Parameters(
         "one" -> "one",
         "two" -> List("one", "two")
       )
@@ -204,28 +203,28 @@ class FailureMessageJsonTest extends FlatSpec {
           |""".stripMargin.trim
     )
 
-    val read = rawJson.unsafeDecodeAs[FailureMessage]
+    val read = rawJson.unsafeDecodeAs[Anomaly]
     assert(read.id.name == failure.id.name,       "id")
     assert(read.message == failure.message,       "message")
     assert(read.parameters == failure.parameters, "parameters")
   }
 
-  behavior of "... serializing composite FailureMessages"
+  behavior of "... serializing composite Anomalies"
 
-  it should "... encode Failures" in {
-    val failure: FailureMessages = Failures(
-      FailureID("test"),
+  it should "... encode Anomalies" in {
+    val failure: Anomalies = Anomalies(
+      AnomalyID("test"),
       "test message",
       NotFoundFailure(
         "one",
-        FailureMessage.Parameters(
+        Anomaly.Parameters(
           "3" -> "1",
           "4" -> List("1", "2")
         )
       ),
       NotFoundFailure(
         "two",
-        FailureMessage.Parameters(
+        Anomaly.Parameters(
           "5" -> "6",
           "6" -> List("6", "7")
         )
@@ -266,13 +265,13 @@ class FailureMessageJsonTest extends FlatSpec {
           |""".stripMargin.trim
     )
 
-    val read = rawJson.unsafeDecodeAs[FailureMessage]
+    val read = rawJson.unsafeDecodeAs[Anomaly]
     assert(read.id.name == failure.id.name,       "id")
     assert(read.message == failure.message,       "message")
     assert(read.parameters == failure.parameters, "parameters")
   }
 
-  it should "... fail when decoding and empty Failures" in {
+  it should "... fail when decoding and empty Anomalies" in {
     val rawJson =
       """
         |{
@@ -282,7 +281,7 @@ class FailureMessageJsonTest extends FlatSpec {
         |}
         |""".stripMargin.trim
 
-    rawJson.decodeAs[FailureMessages] match {
+    rawJson.decodeAs[Anomalies] match {
       case Left(_) => //yey!!!
       case Right(_) => fail("should have failed")
     }

--- a/json/src/test/scala/busymachines/json_test/derive/JsonUtilsTest.scala
+++ b/json/src/test/scala/busymachines/json_test/derive/JsonUtilsTest.scala
@@ -3,6 +3,7 @@ package busymachines.json_test.derive
 import busymachines.json.{JsonDecoding, JsonDecodingFailure, JsonParsing, JsonParsingFailure}
 import busymachines.json_test.AnarchistMelon
 import org.scalatest.{EitherValues, FlatSpec, Matchers}
+import busymachines.json._
 
 /**
   *
@@ -42,7 +43,7 @@ class JsonUtilsTest extends FlatSpec with EitherValues with Matchers {
       """.stripMargin
 
     an[JsonParsingFailure] shouldBe thrownBy {
-      throw JsonParsing.parseString(rawJson).left.value
+      JsonParsing.parseString(rawJson).unsafeGet
     }
   }
 
@@ -117,7 +118,7 @@ class JsonUtilsTest extends FlatSpec with EitherValues with Matchers {
       """.stripMargin
 
     an[JsonParsingFailure] shouldBe thrownBy {
-      throw JsonDecoding.decodeAs[AnarchistMelon](rawJson).left.value
+       JsonDecoding.decodeAs[AnarchistMelon](rawJson).unsafeGet
     }
   }
 
@@ -133,7 +134,7 @@ class JsonUtilsTest extends FlatSpec with EitherValues with Matchers {
       """.stripMargin
 
     the[JsonDecodingFailure] thrownBy {
-      throw JsonDecoding.decodeAs[AnarchistMelon](rawJson).left.value
+      JsonDecoding.decodeAs[AnarchistMelon](rawJson).unsafeGet
     }
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -67,7 +67,7 @@ object Dependencies {
   //======================================== akka ==============================================
   //============================================================================================
 
-  lazy val akkaVersion: String = "2.5.4"
+  lazy val akkaVersion: String = "2.5.8"
 
   lazy val akkaActor:           ModuleID = "com.typesafe.akka" %% "akka-actor"            % akkaVersion
   lazy val akkaStream:          ModuleID = "com.typesafe.akka" %% "akka-stream"           % akkaVersion
@@ -76,7 +76,7 @@ object Dependencies {
   lazy val akkaDistributedData: ModuleID = "com.typesafe.akka" %% "akka-distributed-data" % akkaVersion
   lazy val akkaPersistence:     ModuleID = "com.typesafe.akka" %% "akka-persistence"      % akkaVersion
 
-  lazy val akkaHttpVersion: String   = "10.0.10"
+  lazy val akkaHttpVersion: String   = "10.0.11"
   lazy val akkaHttp:        ModuleID = "com.typesafe.akka" %% "akka-http" % akkaHttpVersion
 
   /**

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -36,7 +36,7 @@ object Dependencies {
 
   lazy val shapeless: ModuleID = "com.chuusai" %% "shapeless" % "2.3.2"
 
-  lazy val catsVersion: String = "1.0.0-RC2"
+  lazy val catsVersion: String = "1.0.0"
 
   lazy val catsCore:    ModuleID = "org.typelevel" %% "cats-core"    % catsVersion
   lazy val catsMacros:  ModuleID = "org.typelevel" %% "cats-macros"  % catsVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   //=================================== http://busymachines.com/ ===============================
   //========================================  busymachines =====================================
   //============================================================================================
-  lazy val bmcv: String = "0.2.0-RC7"
+  lazy val bmcv: String = "0.2.0-RC8"
 
   lazy val bmcCore:       ModuleID = "com.busymachines" %% "busymachines-commons-core"              % bmcv
   lazy val bmcJson:       ModuleID = "com.busymachines" %% "busymachines-commons-json"              % bmcv

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -60,7 +60,7 @@ object Dependencies {
     circeParser
   )
 
-  lazy val attoParser: ModuleID = "org.tpolecat" %% "atto-core" % "0.6.1-M7"
+  lazy val attoParser: ModuleID = "org.tpolecat" %% "atto-core" % "0.6.1"
 
   //============================================================================================
   //================================= http://akka.io/docs/ =====================================

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -44,7 +44,7 @@ object Dependencies {
   lazy val catsLaws:    ModuleID = "org.typelevel" %% "cats-laws"    % catsVersion
   lazy val catsTestkit: ModuleID = "org.typelevel" %% "cats-testkit" % catsVersion
 
-  lazy val catsEffects: ModuleID = "org.typelevel" %% "cats-effect" % "0.6"
+  lazy val catsEffects: ModuleID = "org.typelevel" %% "cats-effect" % "0.7"
 
   lazy val circeVersion: String = "0.9.0-M3"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -69,12 +69,8 @@ object Dependencies {
 
   lazy val akkaVersion: String = "2.5.8"
 
-  lazy val akkaActor:           ModuleID = "com.typesafe.akka" %% "akka-actor"            % akkaVersion
-  lazy val akkaStream:          ModuleID = "com.typesafe.akka" %% "akka-stream"           % akkaVersion
-  lazy val akkaCluster:         ModuleID = "com.typesafe.akka" %% "akka-cluster"          % akkaVersion
-  lazy val akkaClusterSharding: ModuleID = "com.typesafe.akka" %% "akka-cluster-sharding" % akkaVersion
-  lazy val akkaDistributedData: ModuleID = "com.typesafe.akka" %% "akka-distributed-data" % akkaVersion
-  lazy val akkaPersistence:     ModuleID = "com.typesafe.akka" %% "akka-persistence"      % akkaVersion
+  lazy val akkaActor:  ModuleID = "com.typesafe.akka" %% "akka-actor"  % akkaVersion
+  lazy val akkaStream: ModuleID = "com.typesafe.akka" %% "akka-stream" % akkaVersion
 
   lazy val akkaHttpVersion: String   = "10.0.11"
   lazy val akkaHttp:        ModuleID = "com.typesafe.akka" %% "akka-http" % akkaHttpVersion
@@ -86,7 +82,7 @@ object Dependencies {
   //FIXME: required only while circe is at version 0.9.0-M2
   lazy val akkaCirceIntegrationResolver: MavenRepository = Resolver.bintrayRepo("hseeberger", "maven")
 
-  lazy val sprayJsonVersion = "1.3.3"
+  lazy val sprayJsonVersion = "1.3.4"
 
   @scala.deprecated("seriously, migrate to circe, and use the json module", "0.2.0-RC6")
   lazy val sprayJson: ModuleID = "io.spray" %% "spray-json" % sprayJsonVersion

--- a/project/PublishingSettings.scala
+++ b/project/PublishingSettings.scala
@@ -59,6 +59,8 @@ object PublishingSettings {
   )
 
   def noPublishSettings = Seq(
+    publish              := {},
+    publishLocal         := {},
     skip in publishLocal := true,
     skip in publish      := true,
     publishArtifact      := false

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.4
+sbt.version=1.1.0-RC4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,22 @@
+/**
+  * Helps us publish the artifacts to sonatype, which in turn
+  * pushes to maven central.
+  *
+  * https://github.com/xerial/sbt-sonatype
+  */
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
+
+/**
+  *
+  * Signs all the jars, used in conjunction with sbt-sonatype
+  *
+  * https://github.com/sbt/sbt-pgp
+  */
 addSbtPlugin("com.jsuereth"   % "sbt-pgp"      % "1.1.0")
+
+/**
+  * The best thing since sliced bread.
+  *
+  * https://github.com/scalameta/scalafmt
+  */
 addSbtPlugin("com.geirsson"   % "sbt-scalafmt" % "1.3.0")

--- a/rest-core-testkit/README.md
+++ b/rest-core-testkit/README.md
@@ -4,8 +4,8 @@
 
 ## artifacts
 
-Current version is `0.2.0-RC7`. SBT module id:
-`"com.busymachines" %% "busymachines-commons-rest-core-testkit" % "0.2.0-RC7" % test`
+Current version is `0.2.0-RC8`. SBT module id:
+`"com.busymachines" %% "busymachines-commons-rest-core-testkit" % "0.2.0-RC8" % test`
 
 N.B. that this is a testing library, and you should only depend on it in test. Because otherwise you wind up with scalatest and akka http testing libraries on your runtime classpath.
 

--- a/rest-core/README.md
+++ b/rest-core/README.md
@@ -146,7 +146,7 @@ You will probably notice that `ForbiddenFailure` is mapped to a `404 NotFound` s
 This is the copy-pasted partial function from the code linked above:
 ```scala
   /**
-    * Check the scaladoc for each of these failures in case something is not clear,
+    * Check the scaladoc for each of these anomalies in case something is not clear,
     * but for convenience that scaladoc has been copied here as well.
     */
     ExceptionHandler {
@@ -157,7 +157,7 @@ This is the copy-pasted partial function from the code linked above:
       * to tell you anything else"
       */
     case _: NotFoundFailure =>
-      failure(StatusCodes.NotFound)
+      anomaly(StatusCodes.NotFound)
 
     /**
       * Meaning:
@@ -166,7 +166,7 @@ This is the copy-pasted partial function from the code linked above:
       * so for short, you can't find it".
       */
     case _: ForbiddenFailure =>
-      failure(StatusCodes.NotFound)
+      anomaly(StatusCodes.NotFound)
 
     /**
       * Meaning:
@@ -175,10 +175,10 @@ This is the copy-pasted partial function from the code linked above:
       * differently"
       */
     case e: UnauthorizedFailure =>
-      failure(StatusCodes.Unauthorized, e)
+      anomaly(StatusCodes.Unauthorized, e)
 
     case e: DeniedFailure =>
-      failure(StatusCodes.Forbidden, e)
+      anomaly(StatusCodes.Forbidden, e)
 
 
     /**
@@ -200,7 +200,7 @@ This is the copy-pasted partial function from the code linked above:
       * Therefore, specialize frantically.
       */
     case e: InvalidInputFailure =>
-      failure(StatusCodes.BadRequest, e)
+      anomaly(StatusCodes.BadRequest, e)
 
     /**
       * Special type of invalid input.
@@ -209,19 +209,19 @@ This is the copy-pasted partial function from the code linked above:
       * like ids, emails.
       */
     case e: ConflictFailure =>
-      failure(StatusCodes.Conflict, e)
+      anomaly(StatusCodes.Conflict, e)
 
     /**
       * This might be a stretch of an assumption, but usually there's no
       * reason to accumulate messages, except in cases of input validation
       */
-    case es: FailureMessages =>
-      failures(StatusCodes.BadRequest, es)
+    case es: Anomalies =>
+      anomalies(StatusCodes.BadRequest, es)
 
-    case e: Error =>
-      failure(StatusCodes.InternalServerError, e)
+    case e: Catastrophe =>
+      anomaly(StatusCodes.InternalServerError, e)
 
     case e: NotImplementedError =>
-      failure(StatusCodes.NotImplemented, Error(e))
+      anomaly(StatusCodes.NotImplemented, Error(e))
   }
 ```

--- a/rest-core/README.md
+++ b/rest-core/README.md
@@ -4,8 +4,8 @@
 
 ## artifacts
 
-Current version is `0.2.0-RC7`. SBT module id:
-`"com.busymachines" %% "busymachines-commons-rest-core" % "0.2.0-RC7"`
+Current version is `0.2.0-RC8`. SBT module id:
+`"com.busymachines" %% "busymachines-commons-rest-core" % "0.2.0-RC8"`
 
 ### Transitive dependencies
 - busymachines-commons-core

--- a/rest-core/README.md
+++ b/rest-core/README.md
@@ -64,16 +64,16 @@ object MainRestPlaygroundApp extends App {
 }
 
 class HelloWorld extends RestAPI with Directives {
-  import busymachines.core.exceptions._
+  import busymachines.core._
   import akka.http.scaladsl.marshalling.{Marshaller, ToEntityMarshaller}
 
-  override protected def failureMessageMarshaller: ToEntityMarshaller[FailureMessage] =
+  override protected val anomalyMarshaller: ToEntityMarshaller[Anomaly] =
     Marshaller.apply { ec =>
       //intentionally not implemented, because we don't need it. Not an issue if you use `rest-json` module
       ???
     }
 
-  override protected def failureMessagesMarshaller: ToEntityMarshaller[FailureMessages] =
+  override protected val anomaliesMarshaller: ToEntityMarshaller[Anomalies] =
     Marshaller.apply { ec =>
        //intentionally not implemented, because we don't need it. Not an issue if you use `rest-json` module
        ???

--- a/rest-core/src/main/scala/busymachines/rest/RestAPI.scala
+++ b/rest-core/src/main/scala/busymachines/rest/RestAPI.scala
@@ -299,13 +299,17 @@ object RestAPI {
   /**
     * This is a handler for the fabled "Boxed Error" that you get when
     * a future fails with what is marked as an "Error". Unfortunately
-    * this applies to NotImplementedErrors, which is really annoying :/
+    * this applies to NotImplementedErrors, and our Catastrophes,
+    * which is really annoying :/
     */
   private def boxedErrorHandler(
     implicit am: ToEntityMarshaller[Anomaly]
   ): ExceptionHandler = ExceptionHandler {
     case e: NotImplementedError =>
       anomaly(StatusCodes.NotImplemented, CatastrophicError(e))
+
+    case e: Catastrophe =>
+      anomaly(StatusCodes.InternalServerError, e)
 
     case e =>
       anomaly(StatusCodes.InternalServerError, CatastrophicError(e))

--- a/rest-json-spray-testkit/README.md
+++ b/rest-json-spray-testkit/README.md
@@ -6,8 +6,8 @@ _*DO NOT DEPEND ON BOTH THIS MODULE AND `rest-json-testkit`. They share the same
 
 ## artifacts
 
-Current version is `0.2.0-RC7`. SBT module id:
-`"com.busymachines" %% "busymachines-commons-rest-json-spray-testkit" % "0.2.0-RC7" % test`
+Current version is `0.2.0-RC8`. SBT module id:
+`"com.busymachines" %% "busymachines-commons-rest-json-spray-testkit" % "0.2.0-RC8" % test`
 
 ## usage
 It's literally the same as with [`rest-json-testkit`](../rest-json-testkit/README.md), you just need to have the corresponding JSON serializers/deserializers in scope for your tests, and that's it.

--- a/rest-json-spray-testkit/src/test/scala/busymachines/rest_json_spray_test/CRUDRoutesTest.scala
+++ b/rest-json-spray-testkit/src/test/scala/busymachines/rest_json_spray_test/CRUDRoutesTest.scala
@@ -10,7 +10,7 @@ import org.scalatest.FlatSpec
   * @since 07 Sep 2017
   *
   */
-private[rest_json_spray_test] class CRUDRoutesTest extends FlatSpec with JsonRestAPITest with SomeTestDTOJsonCodec {
+class CRUDRoutesTest extends FlatSpec with JsonRestAPITest with SomeTestDTOJsonCodec {
   private lazy val crudAPI = new CRUDRoutesRestAPIForTesting()
   override implicit val testedRoute: Route         = RestAPI.seal(crudAPI).route
   private implicit val cc:           CallerContext = Contexts.none

--- a/rest-json-spray-testkit/src/test/scala/busymachines/rest_json_spray_test/DefaultExceptionHandlerTest.scala
+++ b/rest-json-spray-testkit/src/test/scala/busymachines/rest_json_spray_test/DefaultExceptionHandlerTest.scala
@@ -115,7 +115,7 @@ class DefaultExceptionHandlerTest
     get("/runtime_exception") {
       expectStatus(StatusCodes.InternalServerError)
       val fm = responseAs[FailureMessage]
-      assert(fm.id == FailureID("error"))
+      assert(fm.id == FailureID("CE_0"))
     }
   }
 
@@ -125,7 +125,7 @@ class DefaultExceptionHandlerTest
     get("/not_implemented_boxed") {
       expectStatus(StatusCodes.NotImplemented)
       val fm = responseAs[FailureMessage]
-      assert(fm.id == FailureID("error"))
+      assert(fm.id == FailureID("CE_0"))
     }
   }
 
@@ -135,7 +135,7 @@ class DefaultExceptionHandlerTest
     get("/not_implemented") {
       expectStatus(StatusCodes.NotImplemented)
       val fm = responseAs[FailureMessage]
-      assert(fm.id == FailureID("error"))
+      assert(fm.id == FailureID("CE_0"))
     }
   }
 

--- a/rest-json-spray-testkit/src/test/scala/busymachines/rest_json_spray_test/DefaultExceptionHandlerTest.scala
+++ b/rest-json-spray-testkit/src/test/scala/busymachines/rest_json_spray_test/DefaultExceptionHandlerTest.scala
@@ -11,7 +11,7 @@ import org.scalatest.FlatSpec
   * @since 06 Sep 2017
   *
   */
-private[rest_json_spray_test] class DefaultExceptionHandlerTest
+class DefaultExceptionHandlerTest
     extends FlatSpec with JsonRestAPITest with SomeTestDTOJsonCodec {
   private lazy val defApi = new DefaultExceptionHandlerRestAPIForTesting()
   override implicit val testedRoute: Route         = RestAPI.seal(defApi).route

--- a/rest-json-spray-testkit/src/test/scala/busymachines/rest_json_spray_test/RoutesCompositionTest.scala
+++ b/rest-json-spray-testkit/src/test/scala/busymachines/rest_json_spray_test/RoutesCompositionTest.scala
@@ -11,16 +11,15 @@ import org.scalatest.FlatSpec
   * @since 07 Sep 2017
   *
   */
-private[rest_json_spray_test] class RoutesCompositionTest
-    extends FlatSpec with JsonRestAPITest with SomeTestDTOJsonCodec {
+class RoutesCompositionTest extends FlatSpec with JsonRestAPITest with SomeTestDTOJsonCodec {
   private lazy val combinedAPI: RestAPI = {
     val eh   = new DefaultExceptionHandlerRestAPIForTesting()
     val crud = new CRUDRoutesRestAPIForTesting()
     RestAPI.seal(eh, crud)
   }
 
-  override implicit protected val testedRoute: Route         = combinedAPI.route
   private implicit val cc:                     CallerContext = Contexts.none
+  override implicit protected val testedRoute: Route         = combinedAPI.route
 
   //===========================================================================
 
@@ -29,11 +28,15 @@ private[rest_json_spray_test] class RoutesCompositionTest
   //===========================================================================
 
   it should "return 400 for InvalidInput" in {
-    get("/invalid_input") {
-      expectStatus(StatusCodes.BadRequest)
-      val fm = responseAs[FailureMessage]
-      assert(fm.id == FailureID("4"))
+    //usually it's a bad idea to leave these, but this is for illustrative purposes
+    debug {
+      get("/invalid_input") {
+        expectStatus(StatusCodes.BadRequest)
+        val fm = responseAs[FailureMessage]
+        assert(fm.id == FailureID("4"))
+      }
     }
+
   }
 
   //===========================================================================

--- a/rest-json-spray/README.md
+++ b/rest-json-spray/README.md
@@ -4,8 +4,8 @@
 
 _*DO NOT DEPEND ON BOTH THIS MODULE AND `rest-json`. They share the same packages, and type names. It will end badly, chose one or the other. THIS MODULE WILL RECEIVE WAY LESS ATTENTION THAN THE OTHERS, AND HAS A HIGH CHANCE OF BEING DROPPED.*_
 
-Current version is `0.2.0-RC7`. SBT module id:
-`"com.busymachines" %% "busymachines-commons-rest-json-spray" % "0.2.0-RC7"`
+Current version is `0.2.0-RC8`. SBT module id:
+`"com.busymachines" %% "busymachines-commons-rest-json-spray" % "0.2.0-RC8"`
 
 You should really, really use the [`rest-json`](../rest-json-spray/README.md) module instead. This one is simply a legacy implementation for supporting the now defunct `spray-json`.
 

--- a/rest-json-testkit/README.md
+++ b/rest-json-testkit/README.md
@@ -4,8 +4,8 @@
 
 ## artifacts
 
-Current version is `0.2.0-RC7`. SBT module id:
-`"com.busymachines" %% "busymachines-commons-rest-json-testkit" % "0.2.0-RC7" % test`
+Current version is `0.2.0-RC8`. SBT module id:
+`"com.busymachines" %% "busymachines-commons-rest-json-testkit" % "0.2.0-RC8" % test`
 
 N.B. that this is a testing library, and you should only depend on it in test. Because otherwise you wind up with scalatest and akka http testing libraries on your runtime classpath.
 

--- a/rest-json-testkit/src/test/scala/busymachines/rest_json_test/BasicAuthenticatedRoutesTest.scala
+++ b/rest-json-testkit/src/test/scala/busymachines/rest_json_test/BasicAuthenticatedRoutesTest.scala
@@ -10,7 +10,7 @@ import org.scalatest.FlatSpec
   * @since 07 Sep 2017
   *
   */
-private[rest_json_test] class BasicAuthenticatedRoutesTest extends FlatSpec with JsonRestAPITest {
+class BasicAuthenticatedRoutesTest extends FlatSpec with JsonRestAPITest {
   override implicit protected lazy val testedRoute: Route = {
     val authAPI = new BasicAuthenticatedRoutesRestAPIForTesting()
     RestAPI.seal(authAPI).route

--- a/rest-json-testkit/src/test/scala/busymachines/rest_json_test/BearerAuthenticatedRoutesTest.scala
+++ b/rest-json-testkit/src/test/scala/busymachines/rest_json_test/BearerAuthenticatedRoutesTest.scala
@@ -10,7 +10,7 @@ import org.scalatest.FlatSpec
   * @since 07 Sep 2017
   *
   */
-private[rest_json_test] class BearerAuthenticatedRoutesTest extends FlatSpec with JsonRestAPITest {
+class BearerAuthenticatedRoutesTest extends FlatSpec with JsonRestAPITest {
 
   private lazy val bearerAPI = new BearerAuthenticatedRoutesRestAPIForTesting()
   override implicit val testedRoute: Route = RestAPI.seal(bearerAPI).route

--- a/rest-json-testkit/src/test/scala/busymachines/rest_json_test/CRUDRoutesTest.scala
+++ b/rest-json-testkit/src/test/scala/busymachines/rest_json_test/CRUDRoutesTest.scala
@@ -10,7 +10,7 @@ import org.scalatest.FlatSpec
   * @since 07 Sep 2017
   *
   */
-private[rest_json_test] class CRUDRoutesTest extends FlatSpec with JsonRestAPITest {
+class CRUDRoutesTest extends FlatSpec with JsonRestAPITest {
   private lazy val crudAPI:          CRUDRoutesRestAPIForTesting = new CRUDRoutesRestAPIForTesting()
   override implicit val testedRoute: Route                       = RestAPI.seal(crudAPI).route
   private implicit val cc:           CallerContext               = Contexts.none

--- a/rest-json-testkit/src/test/scala/busymachines/rest_json_test/DefaultExceptionHandlerTest.scala
+++ b/rest-json-testkit/src/test/scala/busymachines/rest_json_test/DefaultExceptionHandlerTest.scala
@@ -128,7 +128,7 @@ class DefaultExceptionHandlerTest extends FlatSpec with JsonRestAPITest {
     get("/runtime_exception") {
       expectStatus(StatusCodes.InternalServerError)
       val fm = responseAs[FailureMessage]
-      assert(fm.id == FailureID("error"))
+      assert(fm.id == FailureID("CE_0"))
     }
   }
 
@@ -138,7 +138,7 @@ class DefaultExceptionHandlerTest extends FlatSpec with JsonRestAPITest {
     get("/not_implemented_boxed") {
       expectStatus(StatusCodes.NotImplemented)
       val fm = responseAs[FailureMessage]
-      assert(fm.id == FailureID("error"))
+      assert(fm.id == FailureID("CE_0"))
     }
   }
 
@@ -148,7 +148,7 @@ class DefaultExceptionHandlerTest extends FlatSpec with JsonRestAPITest {
     get("/not_implemented") {
       expectStatus(StatusCodes.NotImplemented)
       val fm = responseAs[FailureMessage]
-      assert(fm.id == FailureID("error"))
+      assert(fm.id == FailureID("CE_0"))
     }
   }
 

--- a/rest-json-testkit/src/test/scala/busymachines/rest_json_test/DefaultExceptionHandlerTest.scala
+++ b/rest-json-testkit/src/test/scala/busymachines/rest_json_test/DefaultExceptionHandlerTest.scala
@@ -11,7 +11,7 @@ import org.scalatest.FlatSpec
   * @since 06 Sep 2017
   *
   */
-private[rest_json_test] class DefaultExceptionHandlerTest extends FlatSpec with JsonRestAPITest {
+class DefaultExceptionHandlerTest extends FlatSpec with JsonRestAPITest {
   override implicit val testedRoute: Route                                    = RestAPI.seal(defApi).route
   implicit lazy val context:         CallerContext                            = Contexts.none
   private lazy val defApi:           DefaultExceptionHandlerRestAPIForTesting = new DefaultExceptionHandlerRestAPIForTesting()

--- a/rest-json-testkit/src/test/scala/busymachines/rest_json_test/DefaultExceptionHandlerTest.scala
+++ b/rest-json-testkit/src/test/scala/busymachines/rest_json_test/DefaultExceptionHandlerTest.scala
@@ -1,6 +1,6 @@
 package busymachines.rest_json_test
 
-import busymachines.core.exceptions._
+import busymachines.core._
 import busymachines.rest._
 import busymachines.rest_json_test.routes_to_test._
 import org.scalatest.FlatSpec
@@ -17,7 +17,7 @@ class DefaultExceptionHandlerTest extends FlatSpec with JsonRestAPITest {
   private lazy val defApi:           DefaultExceptionHandlerRestAPIForTesting = new DefaultExceptionHandlerRestAPIForTesting()
 
   import SomeTestDTOJsonCodec._
-  import busymachines.json.FailureMessageJsonCodec._
+  import busymachines.json.AnomalyJsonCodec._
 
   behavior of "DefaultExceptionHandler"
 
@@ -66,8 +66,8 @@ class DefaultExceptionHandlerTest extends FlatSpec with JsonRestAPITest {
   it should "return 401 for Unauthorized" in {
     get("/unauthorized") {
       expectStatus(StatusCodes.Unauthorized)
-      val fm = responseAs[FailureMessage]
-      assert(fm.id == FailureID("1"))
+      val fm = responseAs[Anomaly]
+      assert(fm.id == AnomalyID("1"))
     }
   }
 
@@ -76,8 +76,8 @@ class DefaultExceptionHandlerTest extends FlatSpec with JsonRestAPITest {
   it should "return 403 for Denied" in {
     get("/denied") {
       expectStatus(StatusCodes.Forbidden)
-      val fm = responseAs[FailureMessage]
-      assert(fm.id == FailureID("3"))
+      val fm = responseAs[Anomaly]
+      assert(fm.id == AnomalyID("3"))
     }
   }
 
@@ -86,8 +86,8 @@ class DefaultExceptionHandlerTest extends FlatSpec with JsonRestAPITest {
   it should "return 400 for InvalidInput" in {
     get("/invalid_input") {
       expectStatus(StatusCodes.BadRequest)
-      val fm = responseAs[FailureMessage]
-      assert(fm.id == FailureID("4"))
+      val fm = responseAs[Anomaly]
+      assert(fm.id == AnomalyID("4"))
     }
   }
 
@@ -96,8 +96,8 @@ class DefaultExceptionHandlerTest extends FlatSpec with JsonRestAPITest {
   it should "return 400 for InvalidInput — multiple failures" in {
     get("/multiple_failures") {
       expectStatus(StatusCodes.BadRequest)
-      val fm = responseAs[FailureMessages]
-      assert(fm.id == FailureID("1234"))
+      val fm = responseAs[Anomalies]
+      assert(fm.id == AnomalyID("1234"))
       assert(fm.messages.size == 6)
     }
   }
@@ -107,8 +107,8 @@ class DefaultExceptionHandlerTest extends FlatSpec with JsonRestAPITest {
   it should "return 409 for Conflict" in {
     get("/conflict") {
       expectStatus(StatusCodes.Conflict)
-      val fm = responseAs[FailureMessage]
-      assert(fm.id == FailureID("5"))
+      val fm = responseAs[Anomaly]
+      assert(fm.id == AnomalyID("5"))
     }
   }
 
@@ -117,8 +117,8 @@ class DefaultExceptionHandlerTest extends FlatSpec with JsonRestAPITest {
   it should "return 500 for InconsistentStateFailure" in {
     get("/inconsistent_state") {
       expectStatus(StatusCodes.InternalServerError)
-      val fm = responseAs[FailureMessage]
-      assert(fm.id == FailureID("is_state"))
+      val fm = responseAs[Anomaly]
+      assert(fm.id == AnomalyID("IS_0"))
     }
   }
 
@@ -127,8 +127,8 @@ class DefaultExceptionHandlerTest extends FlatSpec with JsonRestAPITest {
   it should "return 500 for RuntimeException" in {
     get("/runtime_exception") {
       expectStatus(StatusCodes.InternalServerError)
-      val fm = responseAs[FailureMessage]
-      assert(fm.id == FailureID("CE_0"))
+      val fm = responseAs[Anomaly]
+      assert(fm.id == AnomalyID("CE_0"))
     }
   }
 
@@ -137,8 +137,8 @@ class DefaultExceptionHandlerTest extends FlatSpec with JsonRestAPITest {
   it should "return 501 for NotImplemented boxed" in {
     get("/not_implemented_boxed") {
       expectStatus(StatusCodes.NotImplemented)
-      val fm = responseAs[FailureMessage]
-      assert(fm.id == FailureID("CE_0"))
+      val fm = responseAs[Anomaly]
+      assert(fm.id == AnomalyID("CE_0"))
     }
   }
 
@@ -147,8 +147,8 @@ class DefaultExceptionHandlerTest extends FlatSpec with JsonRestAPITest {
   it should "return 501 for NotImplemented" in {
     get("/not_implemented") {
       expectStatus(StatusCodes.NotImplemented)
-      val fm = responseAs[FailureMessage]
-      assert(fm.id == FailureID("CE_0"))
+      val fm = responseAs[Anomaly]
+      assert(fm.id == AnomalyID("CE_0"))
     }
   }
 

--- a/rest-json-testkit/src/test/scala/busymachines/rest_json_test/RoutesCompositionTest.scala
+++ b/rest-json-testkit/src/test/scala/busymachines/rest_json_test/RoutesCompositionTest.scala
@@ -11,7 +11,7 @@ import org.scalatest.FlatSpec
   * @since 07 Sep 2017
   *
   */
-private[rest_json_test] class RoutesCompositionTest extends FlatSpec with JsonRestAPITest {
+class RoutesCompositionTest extends FlatSpec with JsonRestAPITest {
   private lazy val combinedAPI: RestAPI = {
     val eh   = new DefaultExceptionHandlerRestAPIForTesting()
     val crud = new CRUDRoutesRestAPIForTesting()

--- a/rest-json-testkit/src/test/scala/busymachines/rest_json_test/RoutesCompositionTest.scala
+++ b/rest-json-testkit/src/test/scala/busymachines/rest_json_test/RoutesCompositionTest.scala
@@ -1,6 +1,6 @@
 package busymachines.rest_json_test
 
-import busymachines.core.exceptions._
+import busymachines.core._
 import busymachines.rest._
 import busymachines.rest_json_test.routes_to_test._
 import org.scalatest.FlatSpec
@@ -23,7 +23,7 @@ class RoutesCompositionTest extends FlatSpec with JsonRestAPITest {
   private implicit val cc:                     CallerContext = Contexts.none
 
   import SomeTestDTOJsonCodec._
-  import busymachines.json.FailureMessageJsonCodec._
+  import busymachines.json.AnomalyJsonCodec._
 
   //===========================================================================
 
@@ -34,8 +34,8 @@ class RoutesCompositionTest extends FlatSpec with JsonRestAPITest {
   it should "return 400 for InvalidInput" in {
     get("/invalid_input") {
       expectStatus(StatusCodes.BadRequest)
-      val fm = responseAs[FailureMessage]
-      assert(fm.id == FailureID("4"))
+      val fm = responseAs[Anomaly]
+      assert(fm.id == AnomalyID("4"))
     }
   }
 

--- a/rest-json-testkit/src/test/scala/busymachines/rest_json_test/routes_to_test/DefaultExceptionHandlerRestAPIForTesting.scala
+++ b/rest-json-testkit/src/test/scala/busymachines/rest_json_test/routes_to_test/DefaultExceptionHandlerRestAPIForTesting.scala
@@ -1,6 +1,6 @@
 package busymachines.rest_json_test.routes_to_test
 
-import busymachines.core.exceptions._
+import busymachines.core._
 import busymachines.rest._
 
 import scala.concurrent.Future
@@ -130,40 +130,40 @@ private[rest_json_test] class DefaultExceptionHandlerRestAPIForTesting
   }
 
   def notFound(s: String): Future[String] = {
-    Future.failed(NotFoundFailure(s, FailureMessage.Parameters("not_found" -> s)))
+    Future.failed(NotFoundFailure(s, Anomaly.Parameters("not_found" -> s)))
   }
 
   def unauthorized(s: String): Future[String] = {
-    Future.failed(UnauthorizedFailure(s, FailureMessage.Parameters("unauthorized" -> s)))
+    Future.failed(UnauthorizedFailure(s, Anomaly.Parameters("unauthorized" -> s)))
   }
 
   def noAccess(s: String): Future[String] = {
-    Future.failed(ForbiddenFailure(s, FailureMessage.Parameters("forbidden" -> s)))
+    Future.failed(ForbiddenFailure(s, Anomaly.Parameters("forbidden" -> s)))
   }
 
   def denied(s: String): Future[String] = {
-    Future.failed(DeniedFailure(s, FailureMessage.Parameters("denied" -> s)))
+    Future.failed(DeniedFailure(s, Anomaly.Parameters("denied" -> s)))
   }
 
   def invalidInput(s: String): Future[String] = {
-    Future.failed(InvalidInputFailure(s, FailureMessage.Parameters("invalidInput" -> s)))
+    Future.failed(InvalidInputFailure(s, Anomaly.Parameters("invalidInput" -> s)))
   }
 
   def conflict(s: String): Future[String] = {
-    Future.failed(ConflictFailure(s, FailureMessage.Parameters("conflict" -> s)))
+    Future.failed(ConflictFailure(s, Anomaly.Parameters("conflict" -> s)))
   }
 
   def failures: Future[String] = {
     Future.failed {
-      Failures(
-        FailureID("1234"),
+      AnomalousFailures(
+        AnomalyID("1234"),
         "a lot of failures",
-        NotFoundFailure("notFound",    FailureMessage.Parameters("one"   -> "1")),
-        UnauthorizedFailure("unauth",  FailureMessage.Parameters("two"   -> "2")),
-        ForbiddenFailure("no_access",  FailureMessage.Parameters("three" -> "3")),
-        DeniedFailure("denied",        FailureMessage.Parameters("four"  -> "4")),
-        InvalidInputFailure("invalid", FailureMessage.Parameters("five"  -> "5")),
-        ConflictFailure("conflict",    FailureMessage.Parameters("six"   -> "6")),
+        NotFoundFailure("notFound",    Anomaly.Parameters("one"   -> "1")),
+        UnauthorizedFailure("unauth",  Anomaly.Parameters("two"   -> "2")),
+        ForbiddenFailure("no_access",  Anomaly.Parameters("three" -> "3")),
+        DeniedFailure("denied",        Anomaly.Parameters("four"  -> "4")),
+        InvalidInputFailure("invalid", Anomaly.Parameters("five"  -> "5")),
+        ConflictFailure("conflict",    Anomaly.Parameters("six"   -> "6")),
       )
     }
   }

--- a/rest-json/README.md
+++ b/rest-json/README.md
@@ -4,8 +4,8 @@
 
 ## artifacts
 
-Current version is `0.2.0-RC7`. SBT module id:
-`"com.busymachines" %% "busymachines-commons-rest-json" % "0.2.0-RC7"`
+Current version is `0.2.0-RC8`. SBT module id:
+`"com.busymachines" %% "busymachines-commons-rest-json" % "0.2.0-RC8"`
 
 ### Transitive dependencies
 - busymachines-commons-core

--- a/rest-json/src/main/scala/busymachines/rest/JsonRestAPI.scala
+++ b/rest-json/src/main/scala/busymachines/rest/JsonRestAPI.scala
@@ -1,7 +1,9 @@
 package busymachines.rest
 
 import akka.http.scaladsl.marshalling.ToEntityMarshaller
-import busymachines.core.exceptions.{FailureMessage, FailureMessages}
+import busymachines.core.{exceptions => dex}
+import busymachines.core._
+import busymachines.json.{AnomalyJsonCodec, FailureMessageJsonCodec}
 
 /**
   *
@@ -14,36 +16,17 @@ import busymachines.core.exceptions.{FailureMessage, FailureMessages}
   */
 trait JsonRestAPI extends RestAPI with jsonrest.JsonSupport {
 
-  import JsonRestAPI._
+  @scala.deprecated("Will be removed in 0.3.0 — Use AnomalyJsonCodec", "0.2.0")
+  protected override val failureMessageMarshaller: ToEntityMarshaller[dex.FailureMessage] =
+    marshaller(FailureMessageJsonCodec.failureMessageCodec)
 
-  protected override val failureMessageMarshaller: ToEntityMarshaller[FailureMessage] =
-    failure.failureMessageMarshaller
+  @scala.deprecated("Will be removed in 0.3.0 — Use AnomalyJsonCodec", "0.2.0")
+  protected override val failureMessagesMarshaller: ToEntityMarshaller[dex.FailureMessages] =
+    marshaller(FailureMessageJsonCodec.failureMessagesCodec)
 
-  protected override val failureMessagesMarshaller: ToEntityMarshaller[FailureMessages] = {
-    failures.failureMessagesMarshaller
-  }
+  override protected val anomalyMarshaller: ToEntityMarshaller[Anomaly] =
+    marshaller(AnomalyJsonCodec.AnomalyCodec)
 
-}
-
-private[rest] object JsonRestAPI {
-
-  private object failure {
-
-    import busymachines.json.FailureMessageJsonCodec._
-    import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
-
-    implicit val failureMessageMarshaller: ToEntityMarshaller[FailureMessage] =
-      marshaller[FailureMessage]
-
-  }
-
-  private object failures {
-
-    import busymachines.json.FailureMessageJsonCodec._
-    import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
-
-    implicit val failureMessagesMarshaller: ToEntityMarshaller[FailureMessages] =
-      marshaller[FailureMessages]
-  }
-
+  override protected val anomaliesMarshaller: ToEntityMarshaller[Anomalies] =
+    marshaller(AnomalyJsonCodec.AnomaliesCodec)
 }

--- a/semver-parsers/README.md
+++ b/semver-parsers/README.md
@@ -7,7 +7,7 @@
 This module is vanilla scala _*only*_, cross-compiled against versions: `2.12.3`.
 
 The full module id is:
-`"com.busymachines" %% "busymachines-commons-semver-parsers" % "0.2.0-RC7"`
+`"com.busymachines" %% "busymachines-commons-semver-parsers" % "0.2.0-RC8"`
 
 ### Transitive dependencies
 

--- a/semver-parsers/src/main/scala/busymachines/semver/semVerParsingFailures.scala
+++ b/semver-parsers/src/main/scala/busymachines/semver/semVerParsingFailures.scala
@@ -1,7 +1,6 @@
 package busymachines.semver
 
-import busymachines.core.exceptions.FailureMessage.Parameters
-import busymachines.core.exceptions._
+import busymachines.core._
 
 /**
   *
@@ -15,9 +14,9 @@ final case class InvalidSemanticVersionFailure(input: String, parseError: String
     extends InvalidSemanticVersionParsingFailure(
       s"Failed to parse semantic version '$input' because: $parseError"
     ) {
-  override def id: FailureID = ParsingFailureIDs.InvalidSemanticVersion
+  override def id: AnomalyID = ParsingAnomalyIDs.InvalidSemanticVersion
 
-  override val parameters: Parameters = Parameters(
+  override val parameters: Anomaly.Parameters = Anomaly.Parameters(
     "input"      -> input,
     "parseError" -> parseError
   )
@@ -27,21 +26,21 @@ final case class InvalidSemanticVersionLabelFailure(input: String, parseError: S
     extends InvalidSemanticVersionParsingFailure(
       s"Failed to parse label of semantic version '$input' because: $parseError"
     ) {
-  override def id: FailureID = ParsingFailureIDs.InvalidSemanticVersionLabel
+  override def id: AnomalyID = ParsingAnomalyIDs.InvalidSemanticVersionLabel
 
-  override val parameters: Parameters = Parameters(
+  override val parameters: Anomaly.Parameters = Anomaly.Parameters(
     "input"      -> input,
     "parseError" -> parseError
   )
 }
 
-object ParsingFailureIDs {
+object ParsingAnomalyIDs {
 
-  case object InvalidSemanticVersion extends FailureID {
+  case object InvalidSemanticVersion extends AnomalyID {
     override def name: String = "BMC_P_1"
   }
 
-  case object InvalidSemanticVersionLabel extends FailureID {
+  case object InvalidSemanticVersionLabel extends AnomalyID {
     override def name: String = "BMC_P_2"
   }
 

--- a/semver/README.md
+++ b/semver/README.md
@@ -7,7 +7,7 @@
 This module is vanilla scala _*only*_, cross-compiled against versions: `2.12.3`.
 
 The full module id is:
-`"com.busymachines" %% "busymachines-commons-semver" % "0.2.0-RC7"`
+`"com.busymachines" %% "busymachines-commons-semver" % "0.2.0-RC8"`
 
 ### Transitive dependencies
 None.

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.0-SNAPSHOT"
+version in ThisBuild := "0.2.0-RC8"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.0-RC7"
+version in ThisBuild := "0.2.0-SNAPSHOT"


### PR DESCRIPTION
* deprecated package `busymachines.core.expcetion`, use `busymachines.core` instead, the former will be removed in `0.3.0`. This new package has syntactically, and semantically similar API, but you can expect the following breaking changes:
  * `FailureMessage` equivalent is `Anomaly`, `ErrorMessage` equivalent is `Catastrophe`
  *  `FailureID` equivalent is `AnomalyID`
* all other modules support the new `core`, and `rest-core` has proper ExceptionHandlers for it.
* upgraded cats to `1.0.0` and the surrounding eco-system except for `circe`. Once `circe` will explicitly depend on cats `1.0.0` we will be releasing version `0.2.0`. The underlying cats used by the older circe is equivalent binary-wise with cats `1.0.0` so the only problem is an annoying sbt eviction warning.